### PR TITLE
fix(index): guard against too large response sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@adobe/helix-service",
+  "name": "@adobe/helix-run-query",
   "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -7192,6 +7192,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-size/-/json-size-1.0.0.tgz",
+      "integrity": "sha1-RjYEbfRw2H/75sE3x2TtDvzVtYg=",
+      "requires": {
+        "utf8-length": "0.0.1"
+      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -16420,6 +16428,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8-length": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
+      "integrity": "sha1-0xXEvtUpyXfxjdNcc9cmKDJ9mto="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "epsagon": "^1.33.3",
     "fs-extra": "^8.1.0",
     "googleapis": "^43.0.0",
+    "json-size": "^1.0.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ async function main(params) {
     };
   }
   try {
-    const results = await execute(
+    const { results, truncated } = await execute(
       params.GOOGLE_CLIENT_EMAIL,
       params.GOOGLE_PRIVATE_KEY,
       params.GOOGLE_PROJECT_ID,
@@ -55,6 +55,7 @@ async function main(params) {
       },
       body: {
         results,
+        truncated,
       },
     };
   } catch (e) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,24 @@ describe('Index Tests', () => {
     });
     assert.equal(typeof result, 'object');
     assert.ok(Array.isArray(result.body.results));
+    assert.ok(!result.body.truncated);
     assert.equal(result.body.results.length, 10);
+  }).timeout(5000);
+
+
+  it('index function truncates long responses', async () => {
+    const result = await index({
+      GOOGLE_CLIENT_EMAIL: util.email,
+      GOOGLE_PRIVATE_KEY: util.key,
+      GOOGLE_PROJECT_ID: util.projectid,
+      token: util.token,
+      __ow_path: 'list-everything',
+      limit: 10000000,
+      service: '0bxMEaYAJV6SoqFlbZ2n1f',
+    });
+    assert.equal(typeof result, 'object');
+    assert.ok(Array.isArray(result.body.results));
+    assert.ok(result.body.truncated);
   }).timeout(5000);
 
   it('index function returns 500 on error', async () => {

--- a/test/testSend.js
+++ b/test/testSend.js
@@ -18,16 +18,16 @@ const send = require('../src/sendquery.js');
 
 describe('bigquery tests', () => {
   it('runs a query', async () => {
-    const result = await send.execute(util.email, util.key, util.projectid, '/list-everything', '0bxMEaYAJV6SoqFlbZ2n1f');
-    assert.ok(Array.isArray(result));
+    const { results } = await send.execute(util.email, util.key, util.projectid, '/list-everything', '0bxMEaYAJV6SoqFlbZ2n1f');
+    assert.ok(Array.isArray(results));
   }).timeout(5000);
 
   it('runs a query with params', async () => {
-    const result = await send.execute(util.email, util.key, util.projectid, 'list-everything', '0bxMEaYAJV6SoqFlbZ2n1f', {
+    const { results } = await send.execute(util.email, util.key, util.projectid, 'list-everything', '0bxMEaYAJV6SoqFlbZ2n1f', {
       limit: 10,
     });
-    assert.ok(Array.isArray(result));
-    assert.equal(result.length, 10);
+    assert.ok(Array.isArray(results));
+    assert.equal(results.length, 10);
   }).timeout(150000);
 
   it('throws without projectid', async () => {


### PR DESCRIPTION
guesses the response size based on the average size of the first ten rows, then truncates the
response (and indicates that it did so)

fixes #2

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
