### PR TITLE
fix(monitoring): adding back missing config

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,12 @@
     "static": [
       "src/queries/next-resource.sql"
     ]
+  },
+  "statuspage": {
+    "name": "Google BigQuery Integration",
+    "group": "Delivery"
+  },
+  "newrelic": {
+    "group_policy": "Delivery Repeated Failure"
   }
 }


### PR DESCRIPTION
Monitoring setup for @adobe/helix-run-query was broken due to missing config.
