### PR TITLE
feat(queries): add generic last-errors query

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,7 @@
     "namespace": "helix",
     "name": "helix-services/run-query@${version}",
     "static": [
-      "src/queries/next-resource.sql",
-      "src/queries/top-pages.sql",
-      "src/queries/top-blogposts.sql",
-      "src/queries/error500.sql",
-      "src/queries/most-visited.sql"
+      "src/queries/*.sql"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,12 @@
     "namespace": "helix",
     "name": "helix-services/run-query@${version}",
     "static": [
-      "src/queries/*.sql"
+      "src/queries/recent-errors.sql",
+      "src/queries/next-resource.sql",
+      "src/queries/top-pages.sql",
+      "src/queries/top-blogposts.sql",
+      "src/queries/error500.sql",
+      "src/queries/most-visited.sql"
     ]
   }
 }

--- a/src/queries/recent-errors.sql
+++ b/src/queries/recent-errors.sql
@@ -1,0 +1,15 @@
+--- description: log entries of requests with 50x status code.
+--- Authorization: fastly
+--- limit: 1000
+--- fromMins: 60
+--- toMins: 0
+SELECT req_url AS url, COUNT(time_start_usec) AS count
+FROM ( 
+  ^myrequests
+)
+WHERE status_code >= "500" AND
+time_start_usec > CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 MINUTE)) AS STRING) AND
+time_start_usec < CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 0 MINUTE)) AS STRING)
+GROUP BY url
+ORDER BY count DESC
+LIMIT 1000

--- a/test/testQueries.js
+++ b/test/testQueries.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const { main } = require('../src/index');
+
+describe('Test Queries', () => {
+  it('recent-errors', async () => {
+    const res = await main({
+      __ow_path: 'recent-errors',
+      GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL,
+      GOOGLE_PRIVATE_KEY: process.env.GOOGLE_PRIVATE_KEY,
+      GOOGLE_PROJECT_ID: process.env.GOOGLE_PROJECT_ID,
+      token: process.env.HLX_FASTLY_AUTH,
+      service: '6v0sHgrPTGUGS5PHOXZ0H1',
+    });
+    assert.ok(res);
+    assert.ok(res.body);
+    console.table(res.body.results);
+  }).timeout(100000);
+
+  it('next-resource', async () => {
+    const res = await main({
+      __ow_path: 'next-resource',
+      GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL,
+      GOOGLE_PRIVATE_KEY: process.env.GOOGLE_PRIVATE_KEY,
+      GOOGLE_PROJECT_ID: process.env.GOOGLE_PROJECT_ID,
+      token: process.env.HLX_FASTLY_AUTH,
+      service: '6v0sHgrPTGUGS5PHOXZ0H1',
+    });
+    assert.ok(res);
+    assert.ok(res.body);
+    console.table(res.body.results);
+  }).timeout(100000);
+});


### PR DESCRIPTION
This is a generalization of the `error500` query that works for any service ID (but requires authentication)
