### PR TITLE
feat(queries): Add RUM Dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       "src/queries/top-blogposts.sql",
       "src/queries/error500.sql",
       "src/queries/most-visited.sql",
-      "src/queries/most-visited-hlx3.sql"
+      "src/queries/most-visited-hlx3.sql",
+      "src/queries/rum-dashboard.sql"
     ]
   }
 }

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -66,9 +66,9 @@ current_rum_by_url_and_weight AS (
         CAST(100 * IF(COUNTIF(lcpgood IS NOT NULL) != 0, COUNTIF(lcpgood = TRUE)/COUNTIF(lcpgood IS NOT NULL), NULL) AS INT64) AS lcpgood,
         CAST(100 * IF(COUNTIF(fidgood IS NOT NULL) != 0, COUNTIF(fidgood = TRUE)/COUNTIF(fidgood IS NOT NULL), NULL) AS INT64) AS fidgood,
         CAST(100 * IF(COUNTIF(clsgood IS NOT NULL) != 0, COUNTIF(clsgood = TRUE)/COUNTIF(clsgood IS NOT NULL), NULL) AS INT64) AS clsgood,
-        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(50)] AS INT64) AS avglcp,
-        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(50)] AS INT64) AS avgfid,
-        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(50)], 3) AS avgcls,
+        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(75)] AS INT64) AS avglcp,
+        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(75)] AS INT64) AS avgfid,
+        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(75)], 3) AS avgcls,
         COUNT(id) AS events,
         weight, url
     FROM current_rum_by_id
@@ -80,9 +80,9 @@ previous_rum_by_url_and_weight AS (
         CAST(100 * IF(COUNTIF(lcpgood IS NOT NULL) != 0, COUNTIF(lcpgood = TRUE)/COUNTIF(lcpgood IS NOT NULL), NULL) AS INT64) AS lcpgood,
         CAST(100 * IF(COUNTIF(fidgood IS NOT NULL) != 0, COUNTIF(fidgood = TRUE)/COUNTIF(fidgood IS NOT NULL), NULL) AS INT64) AS fidgood,
         CAST(100 * IF(COUNTIF(clsgood IS NOT NULL) != 0, COUNTIF(clsgood = TRUE)/COUNTIF(clsgood IS NOT NULL), NULL) AS INT64) AS clsgood,
-        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(50)] AS INT64) AS avglcp,
-        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(50)] AS INT64) AS avgfid,
-        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(50)], 3) AS avgcls,
+        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(75)] AS INT64) AS avglcp,
+        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(75)] AS INT64) AS avgfid,
+        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(75)], 3) AS avgcls,
         COUNT(id) AS events,
         weight, url
     FROM previous_rum_by_id

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -1,0 +1,164 @@
+--- description: Get Helix RUM data for a given domain or owner/repo combination
+--- Authorization: none
+--- limit: 10
+--- domain: -
+--- owner: -
+--- repo: -
+WITH 
+current_data AS (
+  SELECT * 
+  FROM `helix-225321.helix_rum.rum*`
+  WHERE 
+    # use date partitioning to reduce query size
+    _TABLE_SUFFIX <= CONCAT(CAST(EXTRACT(YEAR FROM CURRENT_TIMESTAMP()) AS String), LPAD(CAST(EXTRACT(MONTH FROM CURRENT_TIMESTAMP()) AS String), 2, "0")) AND
+    _TABLE_SUFFIX >= CONCAT(CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS String), LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS String), 2, "0")) AND
+    CAST(time AS STRING) > CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS STRING) AND
+    CAST(time AS STRING) < CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 0 DAY)) AS STRING)
+),
+previous_data AS (
+  SELECT * 
+  FROM `helix-225321.helix_rum.rum*`
+  WHERE 
+    # use date partitioning to reduce query size
+    _TABLE_SUFFIX <= CONCAT(CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS String), LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS String), 2, "0")) AND
+    _TABLE_SUFFIX >= CONCAT(CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)) AS String), LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)) AS String), 2, "0")) AND
+    CAST(time AS STRING) > CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)) AS STRING) AND
+    CAST(time AS STRING) < CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)) AS STRING)
+),
+current_rum_by_id AS (
+    SELECT 
+    IF(MAX(LCP) IS NULL, NULL, IF(MAX(LCP) < 2500, TRUE, FALSE)) AS lcpgood,
+    IF(MAX(FID) IS NULL, NULL, IF(MAX(FID) < 100, TRUE, FALSE)) AS fidgood,
+    IF(MAX(CLS) IS NULL, NULL, IF(MAX(CLS) < 0.1, TRUE, FALSE)) AS clsgood,
+    MAX(host) AS host,
+    MAX(user_agent) AS user_agent,
+    MAX(time) AS time,
+    IF (@domain = "-" AND @repo = "-" AND @owner = "-", REGEXP_EXTRACT(MAX(url), "https://([^/]+)/", 1), MAX(url)) AS url,
+    MAX(LCP) AS LCP,
+    MAX(FID) AS FID,
+    MAX(CLS) AS CLS,
+    MAX(referer) AS referer,
+    MAX(weight) AS weight,
+    id
+  FROM current_data 
+WHERE url LIKE CONCAT("https://", @domain, "/%") OR url LIKE CONCAT("https://%", @repo, "--", @owner, ".hlx%/") OR (@domain = "-" AND @repo = "-" AND @owner = "-")
+GROUP BY id),
+previous_rum_by_id AS (
+    SELECT 
+    IF(MAX(LCP) IS NULL, NULL, IF(MAX(LCP) < 2500, TRUE, FALSE)) AS lcpgood,
+    IF(MAX(FID) IS NULL, NULL, IF(MAX(FID) < 100, TRUE, FALSE)) AS fidgood,
+    IF(MAX(CLS) IS NULL, NULL, IF(MAX(CLS) < 0.1, TRUE, FALSE)) AS clsgood,
+    MAX(host) AS host,
+    MAX(user_agent) AS user_agent,
+    MAX(time) AS time,
+    IF (@domain = "-" AND @repo = "-" AND @owner = "-", REGEXP_EXTRACT(MAX(url), "https://([^/]+)/", 1), MAX(url)) AS url,
+    MAX(LCP) AS LCP,
+    MAX(FID) AS FID,
+    MAX(CLS) AS CLS,
+    MAX(referer) AS referer,
+    MAX(weight) AS weight,
+    id
+  FROM previous_data 
+WHERE url LIKE CONCAT("https://", @domain, "/%") OR url LIKE CONCAT("https://%", @repo, "--", @owner, ".hlx%/") OR (@domain = "-" AND @repo = "-" AND @owner = "-")
+GROUP BY id),
+current_rum_by_url_and_weight AS (
+    SELECT 
+        CAST(100 * IF(COUNTIF(lcpgood IS NOT NULL) != 0, COUNTIF(lcpgood = TRUE)/COUNTIF(lcpgood IS NOT NULL), NULL) AS INT64) AS lcpgood,
+        CAST(100 * IF(COUNTIF(fidgood IS NOT NULL) != 0, COUNTIF(fidgood = TRUE)/COUNTIF(fidgood IS NOT NULL), NULL) AS INT64) AS fidgood,
+        CAST(100 * IF(COUNTIF(clsgood IS NOT NULL) != 0, COUNTIF(clsgood = TRUE)/COUNTIF(clsgood IS NOT NULL), NULL) AS INT64) AS clsgood,
+        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(50)] AS INT64) AS avglcp,
+        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(50)] AS INT64) AS avgfid,
+        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(50)], 3) AS avgcls,
+        COUNT(id) AS events,
+        weight, url
+    FROM current_rum_by_id
+    GROUP BY url, weight
+    ORDER BY events DESC
+), 
+previous_rum_by_url_and_weight AS (
+    SELECT 
+        CAST(100 * IF(COUNTIF(lcpgood IS NOT NULL) != 0, COUNTIF(lcpgood = TRUE)/COUNTIF(lcpgood IS NOT NULL), NULL) AS INT64) AS lcpgood,
+        CAST(100 * IF(COUNTIF(fidgood IS NOT NULL) != 0, COUNTIF(fidgood = TRUE)/COUNTIF(fidgood IS NOT NULL), NULL) AS INT64) AS fidgood,
+        CAST(100 * IF(COUNTIF(clsgood IS NOT NULL) != 0, COUNTIF(clsgood = TRUE)/COUNTIF(clsgood IS NOT NULL), NULL) AS INT64) AS clsgood,
+        CAST(APPROX_QUANTILES(LCP, 100)[OFFSET(50)] AS INT64) AS avglcp,
+        CAST(APPROX_QUANTILES(FID, 100)[OFFSET(50)] AS INT64) AS avgfid,
+        ROUND(APPROX_QUANTILES(CLS, 100)[OFFSET(50)], 3) AS avgcls,
+        COUNT(id) AS events,
+        weight, url
+    FROM previous_rum_by_id
+    GROUP BY url, weight
+    ORDER BY events DESC
+), 
+current_rum_by_url AS (
+  SELECT 
+      SUM(lcpgood * weight) / SUM(weight) AS lcpgood, 
+      SUM(fidgood * weight) / SUM(weight) AS fidgood, 
+      SUM(clsgood * weight) / SUM(weight) AS clsgood,
+      SUM(avglcp * weight) / SUM(weight) AS avglcp, 
+      SUM(avgfid * weight) / SUM(weight) AS avgfid, 
+      ROUND(SUM(avgcls * weight) / SUM(weight), 3) AS avgcls,
+      SUM(events * weight) AS pageviews,
+      url
+
+  FROM current_rum_by_url_and_weight
+  GROUP BY url
+  ORDER BY pageviews DESC
+), 
+previous_rum_by_url AS (
+  SELECT 
+      SUM(lcpgood * weight) / SUM(weight) AS lcpgood, 
+      SUM(fidgood * weight) / SUM(weight) AS fidgood, 
+      SUM(clsgood * weight) / SUM(weight) AS clsgood,
+      SUM(avglcp * weight) / SUM(weight) AS avglcp, 
+      SUM(avgfid * weight) / SUM(weight) AS avgfid, 
+      ROUND(SUM(avgcls * weight) / SUM(weight), 3) AS avgcls,
+      SUM(events * weight) AS pageviews,
+      url
+
+  FROM previous_rum_by_url_and_weight
+  GROUP BY url
+  ORDER BY pageviews DESC
+),
+current_event_count AS (
+  SELECT SUM(events) AS allevents FROM (
+    SELECT MAX(weight) AS events, id 
+    FROM current_data
+    GROUP BY id
+  )
+),
+previous_event_count AS (
+  SELECT SUM(events) AS allevents FROM (
+    SELECT MAX(weight) AS events, id 
+    FROM previous_data
+    GROUP BY id
+  )
+),
+current_truncated_rum_by_url AS (
+  SELECT 
+      CAST(SUM(lcpgood * pageviews) / SUM(pageviews) AS INT64) AS lcpgood, 
+      CAST(SUM(fidgood * pageviews) / SUM(pageviews) AS INT64) AS fidpgood, 
+      CAST(SUM(clsgood * pageviews) / SUM(pageviews) AS INT64) AS clsgood,
+      CAST(SUM(avglcp * pageviews) / SUM(pageviews) AS INT64) AS avglcp, 
+      CAST(SUM(avgfid * pageviews) / SUM(pageviews) AS INT64) AS avgfid, 
+      ROUND(SUM(avgcls * pageviews) / SUM(pageviews), 3) AS avgcls,
+      SUM(pageviews) AS pageviews,
+      100 * SUM(pageviews) / MAX(allevents) AS rumshare,
+      IF(rank > @limit, "Other", url) AS url 
+  FROM (SELECT ROW_NUMBER() OVER (ORDER BY pageviews DESC) AS rank, * FROM current_rum_by_url), current_event_count 
+  GROUP BY url
+),
+previous_truncated_rum_by_url AS (
+  SELECT 
+      CAST(SUM(lcpgood * pageviews) / SUM(pageviews) AS INT64) AS lcpgood, 
+      CAST(SUM(fidgood * pageviews) / SUM(pageviews) AS INT64) AS fidpgood, 
+      CAST(SUM(clsgood * pageviews) / SUM(pageviews) AS INT64) AS clsgood,
+      CAST(SUM(avglcp * pageviews) / SUM(pageviews) AS INT64) AS avglcp, 
+      CAST(SUM(avgfid * pageviews) / SUM(pageviews) AS INT64) AS avgfid, 
+      ROUND(SUM(avgcls * pageviews) / SUM(pageviews), 3) AS avgcls,
+      SUM(pageviews) AS pageviews,
+      100 * SUM(pageviews) / MAX(allevents) AS rumshare,
+      IF(rank > @limit, "Other", url) AS url 
+  FROM (SELECT ROW_NUMBER() OVER (ORDER BY pageviews DESC) AS rank, * FROM previous_rum_by_url), previous_event_count 
+  GROUP BY url
+)
+SELECT * FROM current_truncated_rum_by_url JOIN previous_truncated_rum_by_url USING (url)


### PR DESCRIPTION
adds a query that extracts share of good (according to Google limits) CWV values, average CWV values, estimated number of page views, and estimated share of total RUM traffic for the current and previous 30 day period for an owner-repo pair, a domain name, or all domains with Helix RUM collection set up

## Example Responses

```bash
$ cat src/queries/rum-dashboard.sql | bq query --use_legacy_sql=false --format=prettyjson --parameter domain::- --parameter owner::- --parameter repo::- --parameter limit:INT64:3
```

```jsonc
[
  {
    "avgcls": "0.011", // average CLS for the current period
    "avgcls_1": "0.038", // average CLS for the previous period
    "avgfid": "2", 
    "avgfid_1": "2", 
    "avglcp": "912", 
    "avglcp_1": "904", 
    "clsgood": "68", // percentage of page views that result in a "good" CLS, according to Google in the current period
    "clsgood_1": "57", 
    "fidpgood": "96", 
    "fidpgood_1": "97", 
    "lcpgood": "84", 
    "lcpgood_1": "84", 
    "pageviews": "1346100", // estimated number of page views in the current period
    "pageviews_1": "1381200", 
    "rumshare": "87.968835467", // estimated share of this domain on all RUM traffic (can be used for cost modeling)
    "rumshare_1": "87.174900798", 
    "url": "blog.adobe.com" // the domain - using dashes for all filter parameters enables domain-wide tracking
  }, 
  {
    "avgcls": "0.126", 
    "avgcls_1": "0.157", 
    "avgfid": "2", 
    "avgfid_1": "3", 
    "avglcp": "5295", 
    "avglcp_1": "5768", 
    "clsgood": "40", 
    "clsgood_1": "40", 
    "fidpgood": "100", 
    "fidpgood_1": "100", 
    "lcpgood": "25", 
    "lcpgood_1": "3", 
    "pageviews": "135900", 
    "pageviews_1": "160700", 
    "rumshare": "8.881186197", 
    "rumshare_1": "10.142634346", 
    "url": "theblog--adobe.hlx.page"
  }, 
  {
    "avgcls": null, 
    "avgcls_1": null, 
    "avgfid": null, 
    "avgfid_1": null, 
    "avglcp": null, 
    "avglcp_1": null, 
    "clsgood": null, 
    "clsgood_1": null, 
    "fidpgood": null, 
    "fidpgood_1": null, 
    "lcpgood": null, 
    "lcpgood_1": null, 
    "pageviews": "42400", 
    "pageviews_1": "40100", 
    "rumshare": "2.770877813", 
    "rumshare_1": "2.530924936", 
    "url": "theblog--adobe.hlx.live"
  }, 
  {
    "avgcls": "0.097", 
    "avgcls_1": "0.094", 
    "avgfid": "4", 
    "avgfid_1": "0", 
    "avglcp": "4767", 
    "avglcp_1": "5628", 
    "clsgood": "45", 
    "clsgood_1": "42", 
    "fidpgood": "77", 
    "fidpgood_1": "29", 
    "lcpgood": "25", 
    "lcpgood_1": "17", 
    "pageviews": "5801", 
    "pageviews_1": "2401", 
    "rumshare": "0.379100523", 
    "rumshare_1": "0.15153992", 
    "url": "Other"
  }
]
```

```bash
$ cat src/queries/rum-dashboard.sql | bq query --use_legacy_sql=false --format=prettyjson --parameter domain::blog.adobe.com --parameter owner::adobe --parameter repo::theblog --parameter limit:INT64:10
```

```json
[
  {
    "avgcls": "0.009", 
    "avgcls_1": "0.038", 
    "avgfid": "2", 
    "avgfid_1": "2", 
    "avglcp": "1171", 
    "avglcp_1": "1193", 
    "clsgood": "73", 
    "clsgood_1": "54", 
    "fidpgood": "96", 
    "fidpgood_1": "95", 
    "lcpgood": "83", 
    "lcpgood_1": "81", 
    "pageviews": "279200", 
    "pageviews_1": "310500", 
    "rumshare": "18.243584525", 
    "rumshare_1": "19.596074726", 
    "url": "https://blog.adobe.com/en/publish/2019/05/30/the-future-of-adobe-air.html"
  }, 
  {
    "avgcls": "0.001", 
    "avgcls_1": "0.001", 
    "avgfid": "3", 
    "avgfid_1": "3", 
    "avglcp": "826", 
    "avglcp_1": "936", 
    "clsgood": "95", 
    "clsgood_1": "97", 
    "fidpgood": "95", 
    "fidpgood_1": "97", 
    "lcpgood": "86", 
    "lcpgood_1": "83", 
    "pageviews": "96600", 
    "pageviews_1": "96000", 
    "rumshare": "6.31207115", 
    "rumshare_1": "6.05868977", 
    "url": "https://blog.adobe.com/"
  }, 
  {
    "avgcls": null, 
    "avgcls_1": null, 
    "avgfid": null, 
    "avgfid_1": null, 
    "avglcp": null, 
    "avglcp_1": null, 
    "clsgood": null, 
    "clsgood_1": null, 
    "fidpgood": null, 
    "fidpgood_1": null, 
    "lcpgood": null, 
    "lcpgood_1": null, 
    "pageviews": "41400", 
    "pageviews_1": "44300", 
    "rumshare": "2.70517335", 
    "rumshare_1": "2.795832884", 
    "url": "https://theblog--adobe.hlx.page/"
  }, 
  {
    "avgcls": "0.131", 
    "avgcls_1": "0.197", 
    "avgfid": "3", 
    "avgfid_1": "2", 
    "avglcp": "963", 
    "avglcp_1": "1115", 
    "clsgood": "17", 
    "clsgood_1": "9", 
    "fidpgood": "95", 
    "fidpgood_1": "94", 
    "lcpgood": "88", 
    "lcpgood_1": "87", 
    "pageviews": "31800", 
    "pageviews_1": "41000", 
    "rumshare": "2.077886776", 
    "rumshare_1": "2.587565423", 
    "url": "https://blog.adobe.com/en/publish/2017/07/25/adobe-flash-update.html"
  }, 
  {
    "avgcls": null, 
    "avgcls_1": null, 
    "avgfid": null, 
    "avgfid_1": null, 
    "avglcp": null, 
    "avglcp_1": null, 
    "clsgood": null, 
    "clsgood_1": null, 
    "fidpgood": null, 
    "fidpgood_1": null, 
    "lcpgood": null, 
    "lcpgood_1": null, 
    "pageviews": "42300", 
    "pageviews_1": "39900", 
    "rumshare": "2.763981466", 
    "rumshare_1": "2.518142936", 
    "url": "https://theblog--adobe.hlx.live/"
  }, 
  {
    "avgcls": "0.002", 
    "avgcls_1": "0.002", 
    "avgfid": "3", 
    "avgfid_1": "2", 
    "avglcp": "784", 
    "avglcp_1": "727", 
    "clsgood": "94", 
    "clsgood_1": "95", 
    "fidpgood": "95", 
    "fidpgood_1": "100", 
    "lcpgood": "87", 
    "lcpgood_1": "92", 
    "pageviews": "27200", 
    "pageviews_1": "24400", 
    "rumshare": "1.777311959", 
    "rumshare_1": "1.539916983", 
    "url": "https://blog.adobe.com/404.html"
  }, 
  {
    "avgcls": "0.029", 
    "avgcls_1": "0.03", 
    "avgfid": "3", 
    "avgfid_1": "2", 
    "avglcp": "547", 
    "avglcp_1": "582", 
    "clsgood": "95", 
    "clsgood_1": "95", 
    "fidpgood": "91", 
    "fidpgood_1": "95", 
    "lcpgood": "86", 
    "lcpgood_1": "89", 
    "pageviews": "23500", 
    "pageviews_1": "23900", 
    "rumshare": "1.535545259", 
    "rumshare_1": "1.508361307", 
    "url": "https://blog.adobe.com/en/topics/creative-cloud.html"
  }, 
  {
    "avgcls": "0.048", 
    "avgcls_1": "0.054", 
    "avgfid": "2", 
    "avgfid_1": "2", 
    "avglcp": "314", 
    "avglcp_1": "239", 
    "clsgood": "95", 
    "clsgood_1": "97", 
    "fidpgood": "98", 
    "fidpgood_1": "93", 
    "lcpgood": "99", 
    "lcpgood_1": "96", 
    "pageviews": "22000", 
    "pageviews_1": "21700", 
    "rumshare": "1.437531732", 
    "rumshare_1": "1.369516334", 
    "url": "https://blog.adobe.com/en/topics/news.html"
  }, 
  {
    "avgcls": "0.036", 
    "avgcls_1": "0.062", 
    "avgfid": "5", 
    "avgfid_1": "4", 
    "avglcp": "796", 
    "avglcp_1": "754", 
    "clsgood": "46", 
    "clsgood_1": "39", 
    "fidpgood": "47", 
    "fidpgood_1": "49", 
    "lcpgood": "58", 
    "lcpgood_1": "59", 
    "pageviews": "907600", 
    "pageviews_1": "917800", 
    "rumshare": "59.304718175", 
    "rumshare_1": "57.92359866", 
    "url": "Other"
  }
]
```