### PR TITLE
feat(sql): create queries for media migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
       "src/queries/error500.sql",
       "src/queries/most-visited.sql",
       "src/queries/most-visited-hlx3.sql",
-      "src/queries/rum-dashboard.sql"
+      "src/queries/rum-dashboard.sql",
+      "src/queries/blobs-served.sql"
     ]
   }
 }

--- a/src/queries/blobs-served.sql
+++ b/src/queries/blobs-served.sql
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+*/
+--- description: most served blobs for helix pages
+--- Authorization: none
+--- Cache-Control: max-age=60
+--- fromHours: 720
+--- status: 200
+--- limit: 100
+--- offset: 0
+SELECT * FROM (
+SELECT 
+    IF(req_http_X_Owner != "", req_http_X_Owner, REGEXP_EXTRACT(req_http_host, "[^\\-\\.]+--([^\\-\\.]+)\\.", 1))  AS owner,
+    IF(req_http_X_Repo != "", req_http_X_Repo, 
+        IF(
+            ARRAY_LENGTH(SPLIT(SPLIT(req_http_host, '.')[OFFSET(0)], '--')) = 3, 
+            SPLIT(SPLIT(req_http_host, '.')[OFFSET(0)], '--')[OFFSET(1)], 
+            SPLIT(SPLIT(req_http_host, '.')[OFFSET(0)], '--')[OFFSET(0)]
+                ))AS repo, 
+    REGEXP_EXTRACT(req_http_X_URL, "_([0-9a-f]+)\\.[a-z]+\\??", 1) AS id,
+    REGEXP_EXTRACT(req_http_X_URL, "_[0-9a-f]+\\.([a-z]+)\\??", 1) AS format,
+    TIMESTAMP_MICROS(CAST(MAX(time_start_usec) AS INT64)) AS latestreq,
+    TIMESTAMP_MICROS(CAST(MIN(time_start_usec) AS INT64)) AS earliestreq,
+    COUNT(time_start_usec) AS requests,
+    MAX(req_http_host) AS host,
+FROM `helix-225321.helix_logging_1McGRQOYFuABWBHyD8D4Ux.requests*`
+WHERE req_http_X_URL LIKE "%_media%"
+    AND status_code = CAST(@status AS STRING) AND
+    _TABLE_SUFFIX <= CONCAT(CAST(EXTRACT(YEAR FROM CURRENT_TIMESTAMP()) AS String), LPAD(CAST(EXTRACT(MONTH FROM CURRENT_TIMESTAMP()) AS String), 2, "0")) AND
+    _TABLE_SUFFIX >= CONCAT(CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @fromHours HOUR)) AS String), LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @fromHours HOUR)) AS String), 2, "0")) AND
+    time_start_usec > CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @fromHours HOUR)) AS STRING) AND
+    time_start_usec < CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 0 DAY)) AS STRING)
+GROUP BY owner, repo, id, format
+ORDER BY requests DESC
+)
+WHERE id IS NOT NULL AND format IS NOT NULL
+LIMIT @limit OFFSET @offset


### PR DESCRIPTION
adds one query with following parameters: 
- `fromHours` range of hours to go back in time to aggregate data from (smaller values make faster and cheaper queries) -
- `status` status code of the requests to analyze 
- `limit` number of results to retrieve (results are ordered by frequency) 
- `offset` starting count for pagination

fixes #477


Example:
```bash
$ cat src/queries/blobs-served.sql | bq query --use_legacy_sql=false --parameter fromHours:INT64:720 --parameter status::200 --parameter limit:INT64:10 --parameter offset:INT64:0  --format=prettyjson
```

```jsonc
[
  {
    "earliestreq": "2021-07-20 01:22:43", // timestamp of the earliest request matching
    "format": "png",
    "host": "theblog--adobe.hlx.page", // example host name that served the blob (note that it can contain a branch name)
    "id": "19ca87ee876ef86598e4d5b30f0d310e676ffd7fb",  // blob id
    "latestreq": "2021-08-16 13:32:12", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "60213" // number of requests, sorted descending
  }, 
  {
    "earliestreq": "2021-07-17 13:36:29", 
    "format": "jpeg", 
    "host": "web-vitals--theblog--adobe.hlx.page", 
    "id": "16976bc9a999f65166d903d2db12807d2ddf1a035", 
    "latestreq": "2021-08-16 13:35:45", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43669"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:29", 
    "format": "png", 
    "host": "web-vitals--theblog--adobe.hlx.page", 
    "id": "118cbc28f5de07ee3af710413c4ff26a8d0710a65", 
    "latestreq": "2021-08-16 13:35:46", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43610"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:29", 
    "format": "jpeg", 
    "host": "web-vitals--theblog--adobe.hlx.page", 
    "id": "12deb5c5725925a1c06067e8c436123b92e988ec8", 
    "latestreq": "2021-08-16 13:35:45", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43583"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:22", 
    "format": "jpeg", 
    "host": "theblog--adobe.hlx.page", 
    "id": "1a029310f9c33ed0685a2271b7ef5a32957f31dd7", 
    "latestreq": "2021-08-16 13:36:05", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43420"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:22", 
    "format": "jpeg", 
    "host": "theblog--adobe.hlx.page", 
    "id": "1f338bf036b71408891454368ade39daf96af5b04", 
    "latestreq": "2021-08-16 13:36:05", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43413"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:26", 
    "format": "png", 
    "host": "theblog--adobe.hlx.page", 
    "id": "122091b8be9a2e3d7790fd0d53c2f4bb0621ca89b", 
    "latestreq": "2021-08-16 13:36:08", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43398"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:25", 
    "format": "jpeg", 
    "host": "theblog--adobe.hlx.page", 
    "id": "1cfc716251dd3ce4e7f3e219703ec811a37f36dec", 
    "latestreq": "2021-08-16 13:35:57", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43331"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:20", 
    "format": "png", 
    "host": "theblog--adobe.hlx.page", 
    "id": "174b57d8c7cde4b2ffd7aa952bd469b8520d75767", 
    "latestreq": "2021-08-16 13:36:02", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43298"
  }, 
  {
    "earliestreq": "2021-07-17 13:36:20", 
    "format": "jpeg", 
    "host": "theblog--adobe.hlx.page", 
    "id": "1f1f2c5cceb885501947264299a88ccff9bba7382", 
    "latestreq": "2021-08-16 13:36:02", 
    "owner": "adobe", 
    "repo": "theblog", 
    "requests": "43288"
  }
]

```