### PR TITLE
feat(queries): add daily page views report

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "src/queries/most-visited.sql",
       "src/queries/most-visited-hlx3.sql",
       "src/queries/rum-dashboard.sql",
-      "src/queries/blobs-served.sql"
+      "src/queries/blobs-served.sql",
+      "src/queries/daily-pageviews.sql"
     ]
   }
 }

--- a/src/queries/daily-pageviews.sql
+++ b/src/queries/daily-pageviews.sql
@@ -30,7 +30,7 @@ SELECT
     EXTRACT(YEAR FROM date) AS year,
     EXTRACT(MONTH FROM date) AS month,
     EXTRACT(DAY FROM date) AS day,
-    STRING(date) AS date,
+    STRING(date) AS time,
     COUNT(url) AS urls,
     SUM(weight) AS pageviews,
 FROM pageviews_by_id

--- a/src/queries/daily-pageviews.sql
+++ b/src/queries/daily-pageviews.sql
@@ -1,0 +1,38 @@
+--- description: Get Helix RUM data for a given domain or owner/repo combination
+--- Authorization: none
+--- limit: 30
+--- offset: 0
+--- url: 
+
+WITH 
+current_data AS (
+  SELECT 
+    TIMESTAMP_TRUNC(TIMESTAMP_MILLIS(CAST(time AS INT64)), DAY) AS date,
+     * 
+  FROM `helix-225321.helix_rum.rum*`
+  WHERE 
+    # use date partitioning to reduce query size
+    _TABLE_SUFFIX <= CONCAT(CAST(EXTRACT(YEAR FROM CURRENT_TIMESTAMP()) AS String), LPAD(CAST(EXTRACT(MONTH FROM CURRENT_TIMESTAMP()) AS String), 2, "0")) AND
+    _TABLE_SUFFIX >= CONCAT(CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@limit AS INT64) DAY)) AS String), LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@limit AS INT64) DAY)) AS String), 2, "0")) AND
+    CAST(time AS STRING) > CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@limit AS INT64) DAY)) AS STRING) AND
+    CAST(time AS STRING) < CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@offset AS INT64) DAY)) AS STRING) AND
+    url LIKE CONCAT("https://", @url, "%")
+),
+pageviews_by_id AS (
+    SELECT 
+        MAX(date) AS date, 
+        MAX(url) AS url,
+        id,
+        MAX(weight) AS weight
+    FROM current_data 
+    GROUP BY id)
+SELECT
+    EXTRACT(YEAR FROM date) AS year,
+    EXTRACT(MONTH FROM date) AS month,
+    EXTRACT(DAY FROM date) AS day,
+    date,
+    COUNT(url) AS urls,
+    SUM(weight) AS pageviews,
+FROM pageviews_by_id
+GROUP BY date
+ORDER BY date DESC

--- a/src/queries/daily-pageviews.sql
+++ b/src/queries/daily-pageviews.sql
@@ -1,4 +1,4 @@
---- description: Get Helix RUM data for a given domain or owner/repo combination
+--- description: Get daily page views for a site according to Helix RUM data
 --- Authorization: none
 --- limit: 30
 --- offset: 0
@@ -30,7 +30,7 @@ SELECT
     EXTRACT(YEAR FROM date) AS year,
     EXTRACT(MONTH FROM date) AS month,
     EXTRACT(DAY FROM date) AS day,
-    date,
+    STRING(date) AS date,
     COUNT(url) AS urls,
     SUM(weight) AS pageviews,
 FROM pageviews_by_id

--- a/test/testSend.js
+++ b/test/testSend.js
@@ -142,7 +142,7 @@ describe('bigquery tests', async () => {
         throw e;
       }
     }
-  });
+  }).timeout(10000);
 
   it('throws with bad query', async () => {
     try {


### PR DESCRIPTION
shows the daily page views for the `url` (domain name and optional path) for the last `limit` days (default 30), starting at `offset` (default 0, i.e. today)

Try it here: https://helix-pages.anywhere.run/helix-services/run-query@ci2518/daily-pageviews?url=blog.adobe.com/en&limit=3&offset=1 