### PR TITLE
fix(rum-dashboard): show data even when there is no data in current or previous period

### DIFF
--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -204,4 +204,4 @@ previous_truncated_rum_by_url AS (
   FROM (SELECT ROW_NUMBER() OVER (ORDER BY pageviews DESC) AS rank, * FROM previous_rum_by_url), previous_event_count 
   GROUP BY url
 )
-SELECT * FROM current_truncated_rum_by_url JOIN previous_truncated_rum_by_url USING (url)
+SELECT * FROM current_truncated_rum_by_url FULL OUTER JOIN previous_truncated_rum_by_url USING (url)


### PR DESCRIPTION
by using a FULL OUTER JOIN, records with missing data in either period will no longer be stripped, but simply show `null` values
