### PR TITLE
fix(rum-dashboard): fix ordering of pages

### DIFF
--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -204,4 +204,12 @@ previous_truncated_rum_by_url AS (
   FROM (SELECT ROW_NUMBER() OVER (ORDER BY pageviews DESC) AS rank, * FROM previous_rum_by_url), previous_event_count 
   GROUP BY url
 )
-SELECT * FROM current_truncated_rum_by_url FULL OUTER JOIN previous_truncated_rum_by_url USING (url)
+SELECT 
+  * 
+FROM 
+  current_truncated_rum_by_url FULL OUTER JOIN previous_truncated_rum_by_url 
+  USING (url)
+ORDER BY
+  IF(url="Other", 1, 0),
+  current_truncated_rum_by_url.pageviews DESC,
+  previous_truncated_rum_by_url.pageviews DESC


### PR DESCRIPTION
pages are now always ordered by current page views, then by previous page views. `Other` always comes last
