### PR TITLE
Report Experiment Conversion using RUM data

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
       "src/queries/rum-checkpoints.sql",
       "src/queries/rum-sources.sql",
       "src/queries/rum-targets.sql",
+      "src/queries/rum-experiments.sql",
       "src/queries/pageviews-by-generation.sql"
     ]
   }

--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -43,19 +43,21 @@ AS
     ANY_VALUE(host) AS host,
     MAX(time) AS time,
     checkpoint,
+    source,
     target,
     MAX(weight) AS pageviews,
     ANY_VALUE(generation) AS generation,
+    id,
     ANY_VALUE(url) AS url,
     ANY_VALUE(referer) AS referer,
     ANY_VALUE(user_agent) AS user_agent,
   FROM helix_rum.CLUSTER_EVENTS(filterurl, days_offset, days_count, day_min, day_max, timezone, deviceclass, filtergeneration)
-  GROUP BY id, checkpoint, target;
+  GROUP BY id, checkpoint, target, source;
 
-SELECT * FROM helix_rum.CLUSTER_PAGEVIEWS('blog.adobe.com', 1, 7, '', '', 'GMT', 'desktop', '-')
-ORDER BY time DESC
-LIMIT 10;
+# SELECT * FROM helix_rum.CLUSTER_PAGEVIEWS('blog.adobe.com', 1, 7, '', '', 'GMT', 'desktop', '-')
+# ORDER BY time DESC
+# LIMIT 10;
 
-SELECT * FROM helix_rum.CLUSTER_CHECKPOINTS('blog.adobe.com', -1, -1, '2022-02-01', '2022-02-28', 'GMT', 'mobile', '-')
+SELECT hostname, url, time FROM helix_rum.CLUSTER_CHECKPOINTS('localhost:3000/drafts', -1, -7, '2022-02-01', '2022-05-28', 'GMT', 'all', '-')
 ORDER BY time DESC
 LIMIT 10;

--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION helix_rum.CLUSTER_FILTERCLASS(user_agent STRING, device STRING) 
+  RETURNS BOOLEAN
+  AS (
+    device = "all" OR 
+    (device = "desktop" AND user_agent NOT LIKE "%Mobile%" AND user_agent LIKE "Mozilla%" ) OR 
+    (device = "mobile" AND user_agent LIKE "%Mobile%") OR
+    (device = "bot" AND user_agent NOT LIKE "Mozilla%"));
+
+CREATE OR REPLACE TABLE FUNCTION helix_rum.CLUSTER_EVENTS(filterurl STRING, days_offset INT64, days_count INT64, day_min STRING, day_max STRING, timezone STRING, deviceclass STRING, filtergeneration STRING)
+AS
+  SELECT 
+    *
+  FROM `helix-225321.helix_rum.cluster` 
+  WHERE IF(filterurl = '-', TRUE, url LIKE CONCAT('https://', filterurl, '%'))
+  AND   IF(filterurl = '-', TRUE, hostname = SPLIT(filterurl, '/')[OFFSET(0)])
+  AND   IF(days_offset > 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL days_offset DAY),                TIMESTAMP(day_max, timezone)) >= time
+  AND   IF(days_count > 0,  DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, timezone)) <= time
+  AND   helix_rum.CLUSTER_FILTERCLASS(user_agent, deviceclass)
+  AND   IF(filtergeneration = '-', TRUE, generation = filtergeneration)
+;
+
+CREATE OR REPLACE TABLE FUNCTION helix_rum.CLUSTER_PAGEVIEWS(filterurl STRING, days_offset INT64, days_count INT64, day_min STRING, day_max STRING, timezone STRING, deviceclass STRING, filtergeneration STRING)
+AS
+  SELECT
+    ANY_VALUE(hostname) AS hostname,
+    ANY_VALUE(host) AS host,
+    MAX(time) AS time,
+    MAX(weight) AS pageviews,
+    MAX(LCP) AS LCP,
+    MAX(CLS) AS CLS,
+    MAX(FID) AS FID,
+    ANY_VALUE(generation) AS generation,
+    ANY_VALUE(url) AS url,
+    ANY_VALUE(referer) AS referer,
+    ANY_VALUE(user_agent) AS user_agent
+  FROM helix_rum.CLUSTER_EVENTS(filterurl, days_offset, days_count, day_min, day_max, timezone, deviceclass, filtergeneration)
+  GROUP BY id;
+
+CREATE OR REPLACE TABLE FUNCTION helix_rum.CLUSTER_CHECKPOINTS(filterurl STRING, days_offset INT64, days_count INT64, day_min STRING, day_max STRING, timezone STRING, deviceclass STRING, filtergeneration STRING)
+AS
+  SELECT
+    ANY_VALUE(hostname) AS hostname,
+    ANY_VALUE(host) AS host,
+    MAX(time) AS time,
+    checkpoint,
+    target,
+    MAX(weight) AS pageviews,
+    ANY_VALUE(generation) AS generation,
+    ANY_VALUE(url) AS url,
+    ANY_VALUE(referer) AS referer,
+    ANY_VALUE(user_agent) AS user_agent,
+  FROM helix_rum.CLUSTER_EVENTS(filterurl, days_offset, days_count, day_min, day_max, timezone, deviceclass, filtergeneration)
+  GROUP BY id, checkpoint, target;
+
+SELECT * FROM helix_rum.CLUSTER_PAGEVIEWS('blog.adobe.com', 1, 7, '', '', 'GMT', 'desktop', '-')
+ORDER BY time DESC
+LIMIT 10;
+
+SELECT * FROM helix_rum.CLUSTER_CHECKPOINTS('blog.adobe.com', -1, -1, '2022-02-01', '2022-02-28', 'GMT', 'mobile', '-')
+ORDER BY time DESC
+LIMIT 10;

--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -11,10 +11,10 @@ AS
   SELECT 
     *
   FROM `helix-225321.helix_rum.cluster` 
-  WHERE IF(filterurl = '-', TRUE, url LIKE CONCAT('https://', filterurl, '%'))
-  AND   IF(filterurl = '-', TRUE, hostname = SPLIT(filterurl, '/')[OFFSET(0)])
-  AND   IF(days_offset > 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL days_offset DAY),                TIMESTAMP(day_max, timezone)) >= time
-  AND   IF(days_count > 0,  DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, timezone)) <= time
+  WHERE IF(filterurl = '-', TRUE, (url LIKE CONCAT('https://', filterurl, '%')) OR (filterurl LIKE 'localhost%' AND url LIKE CONCAT('http://', filterurl, '%')))
+  AND   IF(filterurl = '-', TRUE, (hostname = SPLIT(filterurl, '/')[OFFSET(0)]) OR (filterurl LIKE 'localhost:%' AND hostname = 'localhost'))
+  AND   IF(days_offset >= 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL days_offset DAY),                TIMESTAMP(day_max, timezone)) >= time
+  AND   IF(days_count >= 0,  DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, timezone), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, timezone)) <= time
   AND   helix_rum.CLUSTER_FILTERCLASS(user_agent, deviceclass)
   AND   IF(filtergeneration = '-', TRUE, generation = filtergeneration)
 ;

--- a/src/queries/rum-experiments.sql
+++ b/src/queries/rum-experiments.sql
@@ -1,0 +1,112 @@
+CREATE TEMPORARY FUNCTION
+  CDF(nto FLOAT64)
+  RETURNS FLOAT64
+  LANGUAGE js AS """
+{
+    var mean = 0.0;
+    var sigma = 1.0;
+    var z = (nto-mean)/Math.sqrt(2*sigma*sigma);
+    var t = 1/(1+0.3275911*Math.abs(z));
+    var a1 =  0.254829592;
+    var a2 = -0.284496736;
+    var a3 =  1.421413741;
+    var a4 = -1.453152027;
+    var a5 =  1.061405429;
+    var erf = 1-(((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*Math.exp(-z*z);
+    var sign = 1;
+    if(z < 0)
+    {
+        sign = -1;
+    }
+    return (1/2)*(1+sign*erf);
+}
+""";
+
+WITH 
+all_checkpoints AS (
+  SELECT * FROM helix_rum.CLUSTER_CHECKPOINTS('localhost:3000/drafts/uncled', -1, -7, '2022-02-01', '2022-05-28', 'GMT', 'all', '-')
+),
+experiment_checkpoints AS(
+SELECT 
+  source, 
+  target, 
+  id,
+  ANY_VALUE(pageviews) AS pageviews, 
+FROM all_checkpoints
+WHERE checkpoint = 'experiment'
+GROUP BY
+  source,
+  target,
+  id
+),
+converted_checkpoints AS (
+SELECT experiment_checkpoints.source, experiment_checkpoints.target, all_checkpoints.id, all_checkpoints.pageviews
+FROM experiment_checkpoints JOIN all_checkpoints
+  ON experiment_checkpoints.id = all_checkpoints.id
+  WHERE all_checkpoints.checkpoint = 'click'
+),
+conversions_summary AS (
+SELECT 
+  source,
+  target,
+  COUNT(DISTINCT id) AS conversion_events,
+  SUM(pageviews) AS conversions
+FROM converted_checkpoints
+GROUP BY
+  source,
+  target
+),
+experimentations_summary AS (
+SELECT 
+  source,
+  target,
+  COUNT(DISTINCT id) AS experimentation_events,
+  SUM(pageviews) AS experimentations
+FROM experiment_checkpoints
+GROUP BY
+  source,
+  target
+),
+conversion_rates AS (
+SELECT 
+  experimentations_summary.source AS experiment,
+  experimentations_summary.target AS variant,
+  experimentation_events,
+  conversion_events,
+  experimentations,
+  conversions,
+  conversions / experimentations AS conversion_rate
+FROM experimentations_summary FULL JOIN conversions_summary 
+  ON experimentations_summary.source = conversions_summary.source 
+  AND experimentations_summary.target = conversions_summary.target
+)
+
+-- SET
+--   pooled_standard_error = SQRT( pooled_sample_proportion * ( 1 - pooled_sample_proportion ) * ( 1/sessions_variant_1 + 1/sessions_variant_2 ) );
+-- SET
+--   test = (conversions_variant_1/sessions_variant_1 - conversions_variant_2/sessions_variant_2) / pooled_standard_error;
+-- SET
+--   p_value = cdf((-1) * abs(test));
+
+SELECT 
+  l.experiment,
+  l.variant,
+  l.experimentation_events AS variant_experimentation_events,
+  r.experimentation_events AS control_experimentation_events,
+  l.conversion_events AS variant_conversion_events,
+  r.conversion_events AS control_conversion_events,
+  l.experimentations AS variant_experimentations,
+  r.experimentations AS control_experimentations,
+  l.conversions AS variant_conversions,
+  r.conversions AS control_conversions,
+  l.conversion_rate AS variant_conversion_rate,
+  r.conversion_rate AS control_conversion_rate,
+  (l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events) AS pooled_sample_proportion,
+  SQRT(((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1 - ((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1/l.experimentations + 1/r.experimentations ))) AS pooled_standard_error,
+  (l.conversion_rate - r.conversion_rate) / SQRT(((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1 - ((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1/l.experimentations + 1/r.experimentations ))) AS test,
+  CDF((-1) * abs((l.conversion_rate - r.conversion_rate) / SQRT(((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1 - ((l.conversion_events + r.conversion_events) / (l.experimentation_events + r.experimentation_events)) * ( 1/l.experimentations + 1/r.experimentations ))))) AS p_value
+ FROM conversion_rates AS l JOIN conversion_rates AS r ON
+  l.experiment = r.experiment AND
+  l.variant != r.variant
+WHERE r.variant = 'control' AND l.variant != 'control'
+LIMIT 100


### PR DESCRIPTION
The new `rum-experiments` query endpoint supports following parameters:

- `domain`: hostname where experiments are running, use the canonical URL to prevent contamination from staging and dev
- `interval`: how many days of history to consider (default: 30)
- `offset`: move the window of data to be considered by so many days to the past (default: 0)
- `timezone`: timezone to use for full date cut-offs (default: GMT)
- `experiment`: only pull results for one single experiment (default: -, i.e. all)
- `conversioncheckpoint`: this checkpoint will be considered a successful conversion (default: click)

It will report results as follows:

```json
[
  {
    "control_conversion_events": "1",
    "control_conversion_rate": "0.166666667",
    "control_conversions": "1",
    "control_experimentation_events": "6",
    "control_experimentations": "6",
    "experiment": "ccx0039",
    "p_value": "0.028104767312553236",
    "pooled_sample_proportion": "0.2857142857142857",
    "pooled_standard_error": "0.43643578044081077",
    "test": "1.909406538937557",
    "variant": "challenger-1",
    "variant_conversion_events": "1",
    "variant_conversion_rate": "1",
    "variant_conversions": "1",
    "variant_experimentation_events": "1",
    "variant_experimentations": "1"
  }
]
```

