### PR TITLE
Log cost per Query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const bodyData = require('@adobe/helix-shared-body-data');
 const { execute, queryInfo } = require('./sendquery.js');
 const { cleanRequestParams, csvify } = require('./util.js');
 
-async function runExec(params, pathname) {
+async function runExec(params, pathname, log) {
   try {
     if (pathname && pathname.endsWith('.txt')) {
       return queryInfo(pathname, params);
@@ -32,6 +32,7 @@ async function runExec(params, pathname) {
       pathname.replace(/\..*$/, ''),
       params.service,
       cleanRequestParams(params),
+      log,
     );
 
     if (pathname && pathname.endsWith('.csv')) {
@@ -77,7 +78,7 @@ async function run(request, context) {
   params.GOOGLE_PRIVATE_KEY = context.env.GOOGLE_PRIVATE_KEY;
   params.GOOGLE_PROJECT_ID = context.env.GOOGLE_PROJECT_ID;
 
-  return runExec(params, pathname.split('/').pop());
+  return runExec(params, pathname.split('/').pop(), context.log);
 }
 
 /**

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -48,20 +48,21 @@ async function logquerystats(job, query, fn) {
   const centsperterra = 5;
   const minbytes = 1024 * 1024;
   const billed = parseInt(metadata.statistics.query.totalBytesBilled, 10);
-  const billedbytes = Math.min(billed, billed && minbytes);
+  const billedbytes = Math.max(billed, billed && minbytes);
   const billedterrabytes = billedbytes / 1024 / 1024 / 1024 / 1024;
+
   const billedcents = billedterrabytes * centsperterra;
   const cf = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
+    minimumFractionDigits: 2,
+    minimumSignificantDigits: 2,
+    maximumSignificantDigits: 2,
   });
-
   const nf = new Intl.NumberFormat('en-US', {
-    unit: 'GiB',
-    minimumFractionDigits: 4,
-    maximumFractionDigits: 4,
+    style: 'unit',
+    unit: 'gigabyte',
+    maximumSignificantDigits: 3,
   });
   fn(`BiqQuery job ${job
     .id} for ${metadata.statistics.query.cacheHit ? '(cached)' : ''} ${metadata.statistics.query.statementType} ${query} finished with status ${metadata.status.state}, total processed: ${nf.format(parseInt(metadata.statistics.query.totalBytesProcessed, 10) / 1024 / 1024 / 1024)}, total billed: ${nf.format(parseInt(metadata.statistics.query.totalBytesProcessed, 10) / 1024 / 1024 / 1024)}, estimated cost: ${cf.format(billedcents)}`);

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -110,12 +110,14 @@ async function execute(email, key, project, query, service, params = {}) {
             .map((id) => `SELECT ${columnnames.join(', ')} FROM \`${id}.requests*\``)
             .join(' UNION ALL\n');
         },
-      }).then((q) => {
-        dataset.createQueryStream({
+      }).then(async (q) => {
+        const job = await dataset.createQueryJob({
           query: q,
           maxResults: params.limit,
           params: requestParams,
-        })
+        });
+        const stream = job.getQueryResultsStream({});
+        stream
           .on('data', (row) => (spaceleft() ? results.push(row) : resolve({
             headers,
             truncated: true,

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -151,11 +151,14 @@ async function execute(email, key, project, query, service, params = {}, logger 
               description,
               requestParams,
             })))
-            /* c8 ignore next 3 */
-            .on('error', async (e) => {
-              await logquerystats(job, query, logger.warn);
-              reject(e);
-            })
+            .on(
+              'error',
+              /* istanbul ignore next */
+              async (e) => {
+                await logquerystats(job, query, logger.warn);
+                reject(e);
+              },
+            )
             .on('end', async () => {
               await logquerystats(job, query, logger.info);
               resolve({

--- a/test/fixtures/recordings/Index-Tests_647266286/index-function-is-present_1054727320/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/index-function-is-present_1054727320/recording.har
@@ -144,6 +144,136 @@
           "ssl": -1,
           "wait": 317
         }
+      },
+      {
+        "_id": "74742835010d9a9c05895e95bbd1d327",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "gcloud-node-bigquery/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-goog-api-client",
+              "value": "gl-node/16.15.0 gccl/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "Bearer ya29.c.b0AXv0zTNn8Acl-xny023uGfTogLYetU0w6_0Hldp3rvEMolizKdY2hlf3EMD7-pVlFw3pYZfuCd0LlSyK2sEf2ZTW2JSH1DcndF1GKo7CpuZEqq75vwFKY-16W2gQsF-bJgTv1_aFhPnuJKNXZuI8xNLzZyaRf2uSJQ6VOnx0tUL5wSpRo64a6TXMoZ0ybF6mqNOYKuGIUOdJaolmSQmTCXZv2JaswCw........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "bigquery.googleapis.com"
+            }
+          ],
+          "headersSize": 1364,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "location",
+              "value": "US"
+            },
+            {
+              "name": "prettyPrint",
+              "value": "false"
+            }
+          ],
+          "url": "https://bigquery.googleapis.com/bigquery/v2/projects/helix-225321/jobs/3fd25587-564c-4938-a842-c39de7ee8d62?location=US&prettyPrint=false"
+        },
+        "response": {
+          "bodySize": 924,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=UTF-8",
+            "size": 924,
+            "text": "[\"Hw==\",\"iw==\",\"CA==\",\"AA==\",\"AAAAAAL/jVPbbtpAEP0VtH2rAsZXbKSouWApSIQkYNJGVYWW9djZYHuJdw1FiH/veA0pahQ1TyxzzsycMzPekSUvYtInC56+VlBuv7yIBTkjoGiK0R9PN0ZAPR6M4c4L10+T5c1m9HB+jgxeZz1Dxn+3Lcu1LbM/m3bsJLZc1++1Xc9hbSew/Tb1HavN7CCGHoAfexbmSsiSES+WdQWlVrJvGJvNppMKkWZAV1x2mMiNoyRjbRmrUrwAU9I47WigVml8pue3TDCquCjOZ1PsX0ko55BTnqECfK85gzZlTFSFatM458XFaZ8Op3knPfAOtFohVmKiSHhalbo46e+IVnzyqL2i8NbXVlKKvFUCxqWSrdHwdhi1LjKec4V1YgzyQleJ6CKDusLB8/DfQdd0qqiEBponltmzvDh2XMdnbGH7XmB1me9BbMWeCZaHk3Bil2GeqmvrLFqIYsFcs2v1usnCCwITHD8Gi1rM7DoOtRM/Nn0bmO0zsj8jm5IrGHC5EpI3Xsn3yTAK59FkNr6+jEJtIqFVpgaNuNrCqU5tYZ6JNOVFOk/oEuYFzQHzPjS6rzEusHU9yeE4CieX19HwMWx2OIKUsu30FbeY0EwCsmmJJRWUtyLGGZLx5W04QLJexv0RlKT/c0d08z45buAtNdqu9PiV/q27eo5WciQ80qzSjHXzIDbZ738hA8+xSSYPs3DyRJrQBBIooWD/2ylSdfiT39DxojEDbxpbSYX/8YqYrBuxEppr4tql6blOt2s7vcA2HaLJpXqPeTUGRfwOcXyvPh+haHa1VSDvS8FASqgFd48D1lP7kPIXueJZ9hZmlD3DDa6gr8oKGhuQQ6EOo5yGo/A6wgk3UKXdaRKCg7txiNAfB5xR9MYEAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "etag",
+              "value": "XYH/9a6i9NeO6EvYRkHwLQ=="
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=UTF-8"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-Origin, Referer"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 May 2022 13:24:39 GMT"
+            },
+            {
+              "name": "server",
+              "value": "ESF"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 496,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-05-31T13:24:38.667Z",
+        "time": 303,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 303
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Index-Tests_647266286/index-function-returns-an-object_1409163872/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/index-function-returns-an-object_1409163872/recording.har
@@ -144,6 +144,136 @@
           "ssl": -1,
           "wait": 461
         }
+      },
+      {
+        "_id": "74742835010d9a9c05895e95bbd1d327",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "gcloud-node-bigquery/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-goog-api-client",
+              "value": "gl-node/16.15.0 gccl/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "Bearer ya29.c.b0AXv0zTNiK_e-TJTjzV-7KBrPKgT672MJ9icx0lznxGd_KK8piE81adbCNBTKlCNTHLK5neGk_KfyVFiwkDWjIJ3WT5HZsx7KYH6lQLloMU1UnvbF9nz7IPK_qfxPnQK0ONN6091x7h_CCIt435TUJpsVEqA2v23ONQdEOfS2PzRq9YBe-B6WGoua0rlXkTzvbdsnGhCQh5yPneP4tYXBVyTY_dA5318........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "bigquery.googleapis.com"
+            }
+          ],
+          "headersSize": 1364,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "location",
+              "value": "US"
+            },
+            {
+              "name": "prettyPrint",
+              "value": "false"
+            }
+          ],
+          "url": "https://bigquery.googleapis.com/bigquery/v2/projects/helix-225321/jobs/557be38f-edf6-4e1f-9f85-6409537214fd?location=US&prettyPrint=false"
+        },
+        "response": {
+          "bodySize": 945,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=UTF-8",
+            "size": 945,
+            "text": "[\"Hw==\",\"iw==\",\"CA==\",\"AA==\",\"AA==\",\"AA==\",\"AA==\",\"AAL/jVPvb9owEP1XkPdtKpAfTghI1UpLpiG1rIPQapomZJxL6pLENHZgrOJ/38WBDq2q1k+Ye+/u3ru7PJOVKGIyIEuRPlVQ7j48yiU5I6BZitFs9Tgqn4LcfVh/pvbm1voN6f3w/BwZos56gEz8ajuO5zr2YD7reF5vCW6QtCFO/DYFO2n3k8Br+9Tqe27PsWkSY66CLLkWxaquoPVaDbrd7XbbSaVMM2BroTpc5t2jpO7G6a5L+Qhcq+5pxy5qVd339PyUSc60kMX5fIb9KwXlAnImMlSA743g0Gacy6rQbRbnorg47dMRLO+kB96BVivESlwWiUir0hQng2diFJ88aq8ovPWxlZQyb5WAcaVV63p8M45aF5nIhcY6MQZFYapEbJlBXeHgefzvoGs600xBAy0Sx+45fhxTjwacL93A7zsWD3yIndi3wfG526exxzFP17VNFitkseSebTk9K1n6/b4NNIjBYQ63LUqZmwSxHbjA3YCT/RnZlkLDSKi1VKLxSu6n4yhcRNP55GoYhcZEwqpMjxpxtYVTncbCIpNpKop0kbAVLAqWA+a9aXRfY0Ji63qS40kUTodX0fgubHZ4DSnju9kTbjFhmQJksxJLaihvZIwzJJPhTThCslnG7RFUZPDjmZjmeOKHDbykRru1Gb82v3VXnxolR8IdyyrD2DQP4pL9/icy8BybZPJtHk6/kyY0hQRKKPj/dopUE37nN3S8aMzAm8ZWSuN/vCKu6ka8hOaahHFp+x61LJcGtuNSYsilfoW5tlt/+0X8CqG0RrTULLvcaVC3peSgFNSCreOAzdTepPxFLkWWvYQ54w/wBVcw0GUFjQ3IodCHUc7C6/Aqwgk3UGXcGRKCo6+TEKE/2QBlBcYEAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "etag",
+              "value": "lkjDrq8m3hpF41vP0zegWA=="
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=UTF-8"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-Origin, Referer"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 May 2022 13:24:41 GMT"
+            },
+            {
+              "name": "server",
+              "value": "ESF"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 496,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-05-31T13:24:40.700Z",
+        "time": 186,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 186
+        }
       }
     ],
     "pages": [],

--- a/test/fixtures/recordings/Index-Tests_647266286/index-returns-csv-if-path-ends-with-csv_3277224886/recording.har
+++ b/test/fixtures/recordings/Index-Tests_647266286/index-returns-csv-if-path-ends-with-csv_3277224886/recording.har
@@ -144,6 +144,136 @@
           "ssl": -1,
           "wait": 294
         }
+      },
+      {
+        "_id": "74742835010d9a9c05895e95bbd1d327",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "gcloud-node-bigquery/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-goog-api-client",
+              "value": "gl-node/16.15.0 gccl/6.0.0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "Bearer ya29.c.b0AXv0zTMkX4jF1ungLLvMi_DgI_MqfRSMYFVrfIm2Y2XCOuchH5MBB5KHTAcl2t3E1LRqbHszc-q9kDu-QoSnMgzAm0QpiTA4Z9sElnaZbpEoBVRjW6odF3tA8_QTdOkUeOhrPi42PXVwyP6QWWjhm22avhqb4CEtyLc4nUmtIqZicCDOVqyEV0pxe4x0_QemSylVJ_R1-GBBLlrUzZMcqBDwkkq-xE0........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "bigquery.googleapis.com"
+            }
+          ],
+          "headersSize": 1364,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "location",
+              "value": "US"
+            },
+            {
+              "name": "prettyPrint",
+              "value": "false"
+            }
+          ],
+          "url": "https://bigquery.googleapis.com/bigquery/v2/projects/helix-225321/jobs/9ee85002-eae1-4b70-b479-2280c2e44db4?location=US&prettyPrint=false"
+        },
+        "response": {
+          "bodySize": 921,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=UTF-8",
+            "size": 921,
+            "text": "[\"Hw==\",\"iw==\",\"CA==\",\"AAAAAAAC/41T70/iQBD9V8jet4vQn5RCYk6UJkcETqFozOVCtttpXW272N3KoeF/v+kWPHLGnJ9YZt7Me29m+koeeRGTAYl4+lRBuf3yICJyQkDRFKPb2/g6pS89a3hrzC+nL+IuqS6vT08Rweuqe8j477Ztdx3bGiwXnT6A3zVNuw0UrLYb9cx25Pb6iPBNZoPrxpGLtRKyZMKLx7qDUms5MIzNZtNJhUgzoGsuO0zkxkGS8Wwb61I8AFPSOGY0UKs0PsP5LROMKi6K0+UC+SsJ5QpyyjNUgO9nzqBNGRNVodo0znlxdszT4TTvpHvcHlYrxE5MFAlPq1I3J4NXohUfPWqvKLz1tZWUIm+VgHGpZGsyno7D1lnGc66wT4xBXuguIY0yqDvsPY//HXQNp4pKaFKrxLZ6thfHbtf1GYsc3+vbJvM9iO3Ys8D2mNN34y7DOlX31lW0EEXEupZp98wk8vp9C1w/BpvazDJdlzqJH1u+A8zxGdmdkE3JFYy4XAvJG6/kdj4Og1U4X84uhmGgTSS0ytSoEVdbONapLawykaa8SFcJfYRVQXPAug+N7uocF0hdT3I8C4P58CIc3wTNDieQUrZdPOEWE5pJQDQtsaWCcipinCGZDafBCMF6GVeHpCSDn69Ekw/IYQNvpeF2rcev9G/N6rlayQFwQ7NKI56bB3HIbvcLEXiOTTG5XgbzO9KE5pBACQX7304RqsOf/IYOF40VeNNIJRX+xytisiZiJTTXxLVLy+u6pum4vuvYXaLBpXqf65n1t1/E7zJur65SQtHsfKtAXpWCgZRQCzYPA9ZT+xDyN3POs+wtzCi7h++4goEqK2hsQA6F2o9yEUyCixAn3KQq7U6DMDn6MQsw9Qf5062oxgQAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "etag",
+              "value": "yWdQgaz71AW/RKMzoYfuKQ=="
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=UTF-8"
+            },
+            {
+              "name": "vary",
+              "value": "Origin, X-Origin, Referer"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 31 May 2022 13:24:44 GMT"
+            },
+            {
+              "name": "server",
+              "value": "ESF"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "0"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "alt-svc",
+              "value": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            }
+          ],
+          "headersSize": 496,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-05-31T13:24:43.732Z",
+        "time": 188,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 188
+        }
       }
     ],
     "pages": [],

--- a/test/testQueries.js
+++ b/test/testQueries.js
@@ -52,7 +52,7 @@ describe('Test Queries', () => {
     assert.ok(res);
     const results = await res.json();
     assert.ok(results);
-    console.table(results.results);
+    // console.table(results.results);
   }).timeout(100000);
 
   it('most-visited', async () => {


### PR DESCRIPTION
This PR adds the ability to log the cost for each query like this:

```json
{
  "inv": {
    "invocationId": "0193db8de7474bb093db8de7473bb05a",
    "functionName": "/helix-services/run-query/ci3659",
    "transactionId": "1gGh3erNN6SEpnfzDKb2Gre5o3nKBdvp",
    "requestId": "1gGh3erNN6SEpnfzDKb2Gre5o3nKBdvp"
  },
  "level": "info",
  "message": "BiqQuery job 9f4757e0-e8fc-43cf-9598-41b812072cdb for SELECT most-visited-hlx3 finished with status DONE, total processed: 0.729 GB, total billed: 0.729 GB, estimated cost: $0.0036",
  "timestamp": "2022-05-31T14:05:26.085193279Z"
}
```

I'll set up a Coralogix Log2Metrics rule, so that we can keep track of this long-term.