### PR TITLE
ee score with engagement time

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
       "src/queries/recent-errors.sql",
       "src/queries/next-resource.sql",
       "src/queries/top-pages.sql",
+      "src/queries/ee-score.sql",
       "src/queries/guess-hostname.sql",
       "src/queries/content-power-curve.sql",
       "src/queries/most-visited-hlx3.sql",

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -129,7 +129,7 @@ chains AS (
     load,
     click,
     step,
-    COUNTIF(step = 1) OVER(PARTITION BY url ORDER BY visittime) AS chain
+    COUNTIF(step = 1) OVER(PARTITION BY url ORDER BY visittime) AS chainlength
   FROM steps
 ),
 
@@ -162,8 +162,8 @@ powercurvequintiles AS (
     SELECT * FROM (
       SELECT
         host,
-        COUNTIF(chain = 1) AS reach,
-        COUNTIF(chain = 7) AS persistence
+        COUNTIF(chainlength = 1) AS reach,
+        COUNTIF(chainlength = 7) AS persistence
       FROM chains
       GROUP BY host
     )
@@ -300,8 +300,8 @@ lookmeup AS (
           AVG(fid) AS fid,
           AVG(load) AS load,
           AVG(click) AS click,
-          COUNTIF(chain = 1) AS reach,
-          COUNTIF(chain = 7) AS persistence
+          COUNTIF(chainlength = 1) AS reach,
+          COUNTIF(chainlength = 7) AS persistence
         FROM chains
         WHERE (host = @domain OR @domain = "-")
           AND host IS NOT NULL
@@ -323,4 +323,5 @@ lookmeup AS (
 )
 
 #SELECT MIN(num) FROM (SELECT * FROM quintiletable WHERE 0.9841262752758466 >= quintiletable.click)
-SELECT * FROM lookmeup
+SELECT host,experiencescore,perfscore,audiencescore,engagementscore FROM lookmeup
+ORDER BY REGEXP_EXTRACT(host, r"\..*") ASC, host ASC

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -6,37 +6,66 @@
 --- offset: 0
 --- domain: -
 DECLARE upperdate STRING DEFAULT CONCAT(
-  CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@offset AS INT64) DAY)) AS String), 
+  CAST(
+    EXTRACT(
+      YEAR FROM TIMESTAMP_SUB(
+        CURRENT_TIMESTAMP(), INTERVAL CAST(@offset AS INT64) DAY
+      )
+    ) AS String
+  ),
   LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(
-    CURRENT_TIMESTAMP(), 
+    CURRENT_TIMESTAMP(),
     INTERVAL CAST(@offset AS INT64) DAY)) AS String), 2, "0"));
 
 DECLARE lowerdate STRING DEFAULT CONCAT(
-  CAST(EXTRACT(YEAR FROM TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY)) AS String), 
+  CAST(
+    EXTRACT(
+      YEAR FROM TIMESTAMP_SUB(
+        CURRENT_TIMESTAMP(),
+        INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY
+      )
+    ) AS String
+  ),
   LPAD(CAST(EXTRACT(MONTH FROM TIMESTAMP_SUB(
-    CURRENT_TIMESTAMP(), 
-    INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY)) AS String), 2, "0"));
+    CURRENT_TIMESTAMP(),
+    INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY
+    )) AS String), 2, "0"));
 
-DECLARE uppertimestamp STRING DEFAULT CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@offset AS INT64) DAY)) AS STRING);
+DECLARE uppertimestamp STRING DEFAULT CAST(
+  UNIX_MICROS(
+    TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL CAST(@offset AS INT64) DAY)
+  ) AS STRING
+);
 
-DECLARE lowertimestamp STRING DEFAULT CAST(UNIX_MICROS(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY)) AS STRING);
+DECLARE lowertimestamp STRING DEFAULT CAST(
+  UNIX_MICROS(
+    TIMESTAMP_SUB(
+      CURRENT_TIMESTAMP(),
+      INTERVAL SAFE_ADD(CAST(@interval AS INT64), CAST(@offset AS INT64)) DAY
+    )
+  ) AS STRING
+);
 
 CREATE TEMP FUNCTION LABELSCORE(score FLOAT64)
-  RETURNS STRING
-  AS (
-    IF(score <= 1, "A", IF(score <= 2, "B", IF(score <= 3, "C", IF(score <= 4, "D", "F"))))
-  );
+RETURNS STRING
+AS (
+  IF(
+    score <= 1,
+    "A",
+    IF(score <= 2, "B", IF(score <= 3, "C", IF(score <= 4, "D", "F")))
+  )
+);
 
 WITH visits AS (
-  SELECT 
+  SELECT
+    id,
     REGEXP_REPLACE(ANY_VALUE(url), "\\?.*$", "") AS url,
     ANY_VALUE(hostname) AS host,
-    TIMESTAMP_TRUNC(MAX(time), DAY) AS time, 
-    id, 
+    TIMESTAMP_TRUNC(MAX(time), DAY) AS time,
     MAX(weight) AS weight,
-    MAX(LCP) AS LCP,
-    MAX(CLS) AS CLS,
-    MAX(FID) AS FID,
+    MAX(lcp) AS lcp,
+    MAX(cls) AS cls,
+    MAX(fid) AS fid,
     MAX(IF(checkpoint = "top", 1, 0)) AS top,
     MAX(IF(checkpoint = "load", 1, 0)) AS load,
     MAX(IF(checkpoint = "click", 1, 0)) AS click
@@ -44,62 +73,94 @@ WITH visits AS (
     @domain,
     CAST(@offset AS INT64),
     CAST(@interval AS INT64),
-    '',
-    '',
-    'GMT',
-    'all',
-    '-'
+    "",
+    "",
+    "GMT",
+    "all",
+    "-"
   )
   GROUP BY id
 ),
+
 urldays AS (
-  SELECT 
-    time, 
-    url, 
+  SELECT
+    time,
+    url,
     MAX(host) AS host,
-    COUNT(id) AS events, 
+    COUNT(id) AS events,
     SUM(weight) AS visits,
-    AVG(LCP) AS LCP,
-    AVG(CLS) AS CLS,
-    AVG(FID) AS FID,
+    AVG(lcp) AS lcp,
+    AVG(cls) AS cls,
+    AVG(fid) AS fid,
     LEAST(IF(SUM(top) > 0, SUM(load) / SUM(top), 0), 1) AS load,
     LEAST(IF(SUM(top) > 0, SUM(click) / SUM(top), 0), 1) AS click
   FROM visits # FULL JOIN days ON (days.time = visits.time)
   GROUP BY time, url
 ),
+
 steps AS (
-  SELECT time, url, host, events, visits,
-  LCP, CLS, FID, load, click, 
-  TIMESTAMP_DIFF(time, LAG(time) OVER(PARTITION BY url ORDER BY time), DAY) AS step 
+  SELECT
+    time,
+    url,
+    host,
+    events,
+    visits,
+    lcp,
+    cls,
+    fid,
+    load,
+    click,
+    TIMESTAMP_DIFF(
+      time, LAG(time) OVER(PARTITION BY url ORDER BY time), DAY
+    ) AS step
   FROM urldays
 ),
+
 chains AS (
-  SELECT time, url, host, events, visits, 
-  LCP, CLS, FID, load, click, 
-  step, 
-      COUNTIF(step = 1) OVER(PARTITION BY url ORDER BY time) AS chain
-      FROM steps
+  SELECT
+    time,
+    url,
+    host,
+    events,
+    visits,
+    lcp,
+    cls,
+    fid,
+    load,
+    click,
+    step,
+    COUNTIF(step = 1) OVER(PARTITION BY url ORDER BY time) AS chain
+  FROM steps
 ),
+
 urlchains AS (
-  SELECT url, time, chain, events, visits FROM chains
+  SELECT
+    url,
+    time,
+    chain,
+    events,
+    visits
+  FROM chains
   ORDER BY chain DESC
 ),
+
 powercurve AS (
-  SELECT 
-    MAX(chain) AS persistence, 
-    count(url) AS reach
+  SELECT
+    MAX(chain) AS persistence,
+    COUNT(url) AS reach
   FROM urlchains
   GROUP BY chain
   ORDER BY MAX(chain) ASC
   LIMIT 31 OFFSET 1
 ),
+
 powercurvequintiles AS (
-  SELECT 
+  SELECT
     APPROX_QUANTILES(DISTINCT reach, 3) AS reach,
     APPROX_QUANTILES(DISTINCT persistence, 3) AS persistence
   FROM (
     SELECT * FROM (
-      SELECT 
+      SELECT
         host,
         COUNTIF(chain = 1) AS reach,
         COUNTIF(chain = 7) AS persistence
@@ -109,78 +170,139 @@ powercurvequintiles AS (
     WHERE reach > 0 AND persistence > 0 AND host IS NOT NULL
   )
 ),
+
 cwvquintiles AS (
-  SELECT 
-    APPROX_QUANTILES(DISTINCT LCP, 3) AS LCP,
-    APPROX_QUANTILES(DISTINCT CLS, 3) AS CLS,
-    APPROX_QUANTILES(DISTINCT FID, 3) AS FID,
+  SELECT
+    APPROX_QUANTILES(DISTINCT lcp, 3) AS lcp,
+    APPROX_QUANTILES(DISTINCT cls, 3) AS cls,
+    APPROX_QUANTILES(DISTINCT fid, 3) AS fid,
     APPROX_QUANTILES(DISTINCT load, 3) AS load,
-    APPROX_QUANTILES(DISTINCT click, 3) AS click,
+    APPROX_QUANTILES(DISTINCT click, 3) AS click
   FROM chains
 ),
+
 cwvquintiletable AS (
-  SELECT 
-    num, 
-    LCP[OFFSET(num)] AS LCP,
-    CLS[OFFSET(num)] AS CLS,
-    FID[OFFSET(num)] AS FID,
+  SELECT
+    num,
+    lcp[OFFSET(num)] AS lcp,
+    cls[OFFSET(num)] AS cls,
+    fid[OFFSET(num)] AS fid,
     load[OFFSET(3 - num)] AS load,
-    click[OFFSET(3 - num)] AS click,
-  FROM cwvquintiles JOIN UNNEST(GENERATE_ARRAY(0, 3)) AS num
+    click[OFFSET(3 - num)] AS click
+  FROM cwvquintiles INNER JOIN UNNEST(GENERATE_ARRAY(0, 3)) AS num
 ),
+
 powercurvequintiletable AS (
-  SELECT 
-    num, 
+  SELECT
+    num,
     reach[OFFSET(3 - num)] AS reach,
-    persistence[OFFSET(3 - num)] AS persistence,
-  FROM powercurvequintiles JOIN UNNEST(GENERATE_ARRAY(0, 3)) AS num
+    persistence[OFFSET(3 - num)] AS persistence
+  FROM powercurvequintiles INNER JOIN UNNEST(GENERATE_ARRAY(0, 3)) AS num
 ),
+
 quintiletable AS (
   # SELECT * FROM powercurve
-  SELECT * FROM powercurvequintiletable JOIN cwvquintiletable USING (num)
+  SELECT
+    *
+  FROM
+    powercurvequintiletable
+  INNER JOIN
+    cwvquintiletable ON powercurvequintiletable.num = cwvquintiletable.num
 ),
+
 lookmeup AS (
-SELECT
-  host,
-  LABELSCORE((((clsscore + lcpscore + fidscore) / 3) + ((reachscore + persistencescore + loadscore) / 3) + (clickscore)) / 3) AS experiencescore,
-  LABELSCORE((clsscore + lcpscore + fidscore) / 3) AS perfscore,
-  LABELSCORE((reachscore + persistencescore + loadscore) / 3) AS audiencescore,
-  LABELSCORE(clickscore) AS engagementscore,
+  SELECT
+    host,
+    LABELSCORE(
+      (
+        (
+          (clsscore + lcpscore + fidscore) / 3
+        ) + ((reachscore + persistencescore + loadscore) / 3) + (clickscore)
+      ) / 3
+    ) AS experiencescore,
+    LABELSCORE((clsscore + lcpscore + fidscore) / 3) AS perfscore,
+    LABELSCORE(
+      (reachscore + persistencescore + loadscore) / 3
+    ) AS audiencescore,
+    LABELSCORE(clickscore) AS engagementscore
   FROM (
-    SELECT 
+    SELECT
       host,
-      chained.CLS AS CLS,
+      chained.cls AS cls,
       # (SELECT num FROM quintiletable WHERE quintiletable.CLS <= chained.CLS) AS clsscore,
-      (SELECT MAX(num) FROM (SELECT num FROM quintiletable WHERE quintiletable.CLS <= chained.CLS)) AS clsscore,
-      chained.LCP AS LCP,
-      (SELECT MAX(num) FROM (SELECT num FROM quintiletable WHERE quintiletable.LCP <= chained.LCP)) AS lcpscore,
-      chained.FID AS FID,
-      (SELECT MAX(num) FROM (SELECT num FROM quintiletable WHERE quintiletable.FID <= chained.FID)) AS fidscore,
+      chained.lcp AS lcp,
+      chained.fid AS fid,
       chained.load AS load,
-      (SELECT MIN(num) FROM (SELECT num FROM quintiletable WHERE chained.load >= quintiletable.load)) AS loadscore,
       chained.click AS click,
-      (SELECT MIN(num) FROM (SELECT num FROM quintiletable WHERE chained.click >= quintiletable.click)) AS clickscore,
       chained.reach AS reach,
-      (SELECT MIN(num) FROM (SELECT num FROM quintiletable WHERE chained.reach >= quintiletable.reach)) AS reachscore,
       chained.persistence AS persistence,
-      (SELECT MIN(num) FROM (SELECT num FROM quintiletable WHERE chained.persistence >= quintiletable.persistence)) AS persistencescore,
-      FROM (
-      SELECT 
-        host, 
-        AVG(CLS) AS CLS,
-        AVG(LCP) AS LCP,
-        AVG(FID) AS FID,
-        AVG(load) AS load,
-        AVG(click) AS click,
-        COUNTIF(chain = 1) AS reach,
-        COUNTIF(chain = 7) AS persistence
-      FROM chains 
-      WHERE (host = @domain OR @domain = "-") 
-        AND host IS NOT NULL
-        AND host NOT LIKE "%.hlx.%"
-      GROUP BY host
-      ORDER BY host DESC
-    ) AS chained
+      (
+        SELECT MAX(num)
+        FROM
+          (SELECT num FROM quintiletable WHERE quintiletable.cls <= chained.cls)
+      ) AS clsscore,
+      (
+        SELECT MAX(num)
+        FROM
+          (SELECT num FROM quintiletable WHERE quintiletable.lcp <= chained.lcp)
+      ) AS lcpscore,
+      (
+        SELECT MAX(num)
+        FROM
+          (SELECT num FROM quintiletable WHERE quintiletable.fid <= chained.fid)
+      ) AS fidscore,
+      (
+        SELECT MIN(num)
+        FROM
+          (
+            SELECT num
+            FROM quintiletable WHERE chained.load >= quintiletable.load
+          )
+      ) AS loadscore,
+      (
+        SELECT MIN(num)
+        FROM
+          (
+            SELECT num
+            FROM quintiletable WHERE chained.click >= quintiletable.click
+          )
+      ) AS clickscore,
+      (
+        SELECT MIN(num)
+        FROM
+          (
+            SELECT num
+            FROM quintiletable WHERE chained.reach >= quintiletable.reach
+          )
+      ) AS reachscore,
+      (
+        SELECT MIN(num)
+        FROM
+          (
+            SELECT num
+            FROM
+              quintiletable
+            WHERE chained.persistence >= quintiletable.persistence
+          )
+      ) AS persistencescore
+    FROM (
+        SELECT
+          host,
+          AVG(cls) AS cls,
+          AVG(lcp) AS lcp,
+          AVG(fid) AS fid,
+          AVG(load) AS load,
+          AVG(click) AS click,
+          COUNTIF(chain = 1) AS reach,
+          COUNTIF(chain = 7) AS persistence
+        FROM chains
+        WHERE (host = @domain OR @domain = "-")
+          AND host IS NOT NULL
+          AND host NOT LIKE "%.hlx.%"
+          AND host != "localhost"
+        GROUP BY host
+        ORDER BY host DESC
+      ) AS chained
   )
   WHERE host = @domain OR (@domain = "-"
     AND clsscore IS NOT NULL
@@ -192,5 +314,6 @@ SELECT
     AND persistencescore IS NOT NULL
   )
 )
+
 #SELECT MIN(num) FROM (SELECT * FROM quintiletable WHERE 0.9841262752758466 >= quintiletable.click)
 SELECT * FROM lookmeup

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -203,7 +203,14 @@ powercurvequintiletable AS (
 quintiletable AS (
   # SELECT * FROM powercurve
   SELECT
-    *
+    cls,
+    lcp,
+    fid,
+    load,
+    click,
+    reach,
+    persistence,
+    cwvquintiletable.num AS num
   FROM
     powercurvequintiletable
   INNER JOIN

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -323,5 +323,11 @@ lookmeup AS (
 )
 
 #SELECT MIN(num) FROM (SELECT * FROM quintiletable WHERE 0.9841262752758466 >= quintiletable.click)
-SELECT host,experiencescore,perfscore,audiencescore,engagementscore FROM lookmeup
+SELECT
+  host,
+  experiencescore,
+  perfscore,
+  audiencescore,
+  engagementscore
+FROM lookmeup
 ORDER BY REGEXP_EXTRACT(host, r"\..*") ASC, host ASC

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -133,26 +133,26 @@ chains AS (
   FROM steps
 ),
 
-urlchains AS (
-  SELECT
-    url,
-    time,
-    chain,
-    events,
-    visits
-  FROM chains
-  ORDER BY chain DESC
-),
-
-powercurve AS (
-  SELECT
-    MAX(chain) AS persistence,
-    COUNT(url) AS reach
-  FROM urlchains
-  GROUP BY chain
-  ORDER BY MAX(chain) ASC
-  LIMIT 31 OFFSET 1
-),
+# urlchains AS (
+#  SELECT
+#    url,
+#    time,
+#    chain,
+#    events,
+#    visits
+#  FROM chains
+#  ORDER BY chain DESC
+# ),
+#
+# powercurve AS (
+#  SELECT
+#    MAX(chain) AS persistence,
+#    COUNT(url) AS reach
+#  FROM urlchains
+#  GROUP BY chain
+#  ORDER BY MAX(chain) ASC
+#  LIMIT 31 OFFSET 1
+# ),
 
 powercurvequintiles AS (
   SELECT
@@ -203,13 +203,13 @@ powercurvequintiletable AS (
 quintiletable AS (
   # SELECT * FROM powercurve
   SELECT
-    cls,
-    lcp,
-    fid,
-    load,
-    click,
-    reach,
-    persistence,
+    cwvquintiletable.cls AS cls,
+    cwvquintiletable.lcp AS lcp,
+    cwvquintiletable.fid AS fid,
+    cwvquintiletable.load AS load,
+    cwvquintiletable.click AS click,
+    powercurvequintiletable.reach AS reach,
+    powercurvequintiletable.persistence AS persistence,
     cwvquintiletable.num AS num
   FROM
     powercurvequintiletable


### PR DESCRIPTION
- build(deploy): include ee-score in executable queries
- fix(ee-score): exclude localhost from reports
- refactor(ee-score): no * select
- refactor(ee-score): remove unused ctes
- refactor(ee-score): rename `time` to `visittime` to avoid conflict with built-in function `TIME`
- refactor(ee-score): rename `chain` to `chainlength`, remove select *, add order of hostnames
- style(ee-score): sqlfluff formatting
- feat(ee-score): include engagementduration in score value

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
