### PR TITLE
fix(rum-sources): make sure checkpoint is always treated as a string

### DIFF
--- a/src/queries/rum-sources.sql
+++ b/src/queries/rum-sources.sql
@@ -9,9 +9,7 @@
 
 WITH
 current_data AS (
-  SELECT
-    *,
-    TIMESTAMP_TRUNC(time, DAY) AS date
+  SELECT *
   FROM helix_rum.CLUSTER_CHECKPOINTS(
     @url,
     CAST(@offset AS INT64),
@@ -35,7 +33,9 @@ sources AS (
   FROM current_data
   WHERE
     source IS NOT NULL AND (
-      @checkpoint = '-' OR CAST(@checkpoint AS STRING) = checkpoint
+      CAST(
+        @checkpoint AS STRING
+      ) = '-' OR CAST(@checkpoint AS STRING) = checkpoint
     )
   GROUP BY source, id, checkpoint
 )

--- a/src/queries/rum-sources.sql
+++ b/src/queries/rum-sources.sql
@@ -7,11 +7,11 @@
 --- url: -
 --- checkpoint: -
 
-WITH 
+WITH
 current_data AS (
-  SELECT 
-    TIMESTAMP_TRUNC(time, DAY) AS date,
-     * 
+  SELECT
+    *,
+    TIMESTAMP_TRUNC(time, DAY) AS date
   FROM helix_rum.CLUSTER_CHECKPOINTS(
     @url,
     CAST(@offset AS INT64),
@@ -23,28 +23,32 @@ current_data AS (
     '-'
   )
 ),
+
 sources AS (
- SELECT 
+  SELECT
     id,
-    source, 
+    source,
     checkpoint,
-    MAX(url) AS url, 
+    MAX(url) AS url,
     MAX(pageviews) AS views,
-    SUM(pageviews) AS actions,
-  FROM current_data 
-  WHERE source IS NOT NULL AND (@checkpoint = '-' OR CAST(@checkpoint AS STRING) = checkpoint)
-  GROUP BY source, id, checkpoint 
+    SUM(pageviews) AS actions
+  FROM current_data
+  WHERE
+    source IS NOT NULL AND (
+      @checkpoint = '-' OR CAST(@checkpoint AS STRING) = checkpoint
+    )
+  GROUP BY source, id, checkpoint
 )
 
-SELECT 
+SELECT
+  checkpoint,
+  source,
   COUNT(id) AS ids,
   COUNT(DISTINCT url) AS pages,
   APPROX_TOP_COUNT(url, 1)[OFFSET(0)].value AS topurl,
   SUM(views) AS views,
   SUM(actions) AS actions,
-  SUM(actions) / SUM(views) AS actions_per_view,
-  checkpoint,
-  source,
+  SUM(actions) / SUM(views) AS actions_per_view
 FROM sources
 GROUP BY source, checkpoint
 ORDER BY views DESC

--- a/src/queries/rum-sources.sql
+++ b/src/queries/rum-sources.sql
@@ -32,7 +32,7 @@ sources AS (
     MAX(pageviews) AS views,
     SUM(pageviews) AS actions,
   FROM current_data 
-  WHERE source IS NOT NULL AND (@checkpoint = '-' OR @checkpoint = checkpoint)
+  WHERE source IS NOT NULL AND (@checkpoint = '-' OR CAST(@checkpoint AS STRING) = checkpoint)
   GROUP BY source, id, checkpoint 
 )
 


### PR DESCRIPTION
this should fix the `checkpoint=404` issues
