### PR TITLE
Support synthetic checkpoints for dwell time analysis

### DIFF
--- a/src/queries/rum-checkpoints.sql
+++ b/src/queries/rum-checkpoints.sql
@@ -13,7 +13,7 @@ weightdata AS (
     MAX(pageviews) AS weight,
     ANY_VALUE(url) AS url,
     ANY_VALUE(generation) AS generation
-  FROM helix_rum.CLUSTER_CHECKPOINTS(
+  FROM helix_rum.CLUSTER_SYNTHETIC_CHECKPOINTS(
     @domain,
     0, # offset in days from today, not used
     CAST(@interval AS INT64), # interval in days to consider


### PR DESCRIPTION
- feat(rum-common): add table valued function for synthetic checkpoints
- feat(rum-checkpoints): consider synthetic checkpoints

With this PR, the checkpoints report will insert syntethic checkpoints (not tracked, but inferred from the data) for certain dwell time milestones.
This will allow us to infer how long visitors stay on the page.
