### PR TITLE
fix: catch invalid query and return 400

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,12 @@ async function runExec(params, pathname, log) {
       },
     });
   } catch (e) {
+    let status = e.statusCode || 500;
+    if (e?.errors?.[0].reason === 'invalidQuery') {
+      status = 400;
+    }
     return new Response(e.message, {
-      status: e.statusCode || 500,
+      status,
       headers: {
         'x-error': cleanupHeaderValue(e.message),
       },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -283,4 +283,21 @@ describe('Index Tests', async () => {
     assert.equal(text.split('\n')[0], 'client_geo_city,client_as_name,client_geo_conn_speed,client_geo_continent_code,client_geo_country_code,client_geo_gmt_offset,client_geo_latitude,client_geo_longitude,client_geo_metro_code,client_geo_postal_code,client_geo_region,client_ip_hashed,client_ip_masked,fastly_info_state,req_http_X_Ref,req_http_X_Repo,req_http_X_Static,req_http_X_Strain,req_http_X_Owner,server_datacenter,server_region,req_http_host,req_http_X_Host,req_url,req_http_X_URL,req_http_X_CDN_Request_ID,vcl_sub,time_start_usec,time_end_usec,time_elapsed_usec,resp_http_x_openwhisk_activation_id,resp_http_X_Version,req_http_Referer,req_http_User_Agent,resp_http_Content_Type,service_config,status_code');
     assert.equal(response.headers.get('content-type'), 'text/csv');
   });
+
+  it('index returns 400 if some parameter is invalid', async () => {
+    const response = await index(new Request('https://helix-run-query.com/list-everything.csv?limit=-', {
+      headers: {
+        'x-service': service,
+      },
+    }), {
+      env: {
+        GOOGLE_CLIENT_EMAIL: env.email,
+        GOOGLE_PRIVATE_KEY: env.key,
+        GOOGLE_PROJECT_ID: env.projectid,
+      },
+    });
+
+    const text = await response.text();
+    assert.equal(response.status, 400, text);
+  });
 });


### PR DESCRIPTION
When some parameter value to `helix-run-query` is invalid (e.g. `-` for an integer), it reports a 500 error in our escalation channel.

This PR catches errors reported as invalidQuery and returns a 400 instead.