### PR TITLE
RUM Interval Reporting

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -9,7 +9,7 @@ capitalisation_policy = upper
 
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = upper
-ignore_words_regex = ^`helix-225321.helix_rum.[A-Z_]+`$
+ignore_words_regex = ^`helix-225321.helix_rum.[A-Z0-9_]+`$
 
 [sqlfluff:rules:layout.long_lines]
 ignore_comment_lines = true

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -9,7 +9,7 @@ capitalisation_policy = upper
 
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = upper
-ignore_words_regex = ^`helix-225321.helix_rum.[A-Z0-9_]+`$
+ignore_words_regex = ^`(helix-225321\.(helix_rum|fn)\.[^`]+)`$
 
 [sqlfluff:rules:layout.long_lines]
 ignore_comment_lines = true

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
       "src/queries/rum-content-requests.sql",
       "src/queries/rum-dashboard.sql",
       "src/queries/rum-experiments.sql",
+      "src/queries/rum-intervals.sql",
       "src/queries/rum-pageviews.sql",
       "src/queries/rum-sources-targets.sql",
       "src/queries/rum-sources.sql",

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -195,6 +195,24 @@ all_results AS (
     IF(
       l.interval_name != r.interval_name,
       1 - CDF(
+        ABS(l.conversion_rate - r.conversion_rate) / SQRT(
+          (
+            (
+              l.conversions + r.conversions
+            ) / (l.events + r.events)
+          ) * (
+            1 - (
+              (
+                l.conversions + r.conversions
+              ) / (l.events + r.events)
+            ) * (1 / l.events + 1 / r.events)
+          )
+        )
+      ), NULL
+    ) AS conversion_p_value,
+    IF(
+      l.interval_name != r.interval_name,
+      1 - CDF(
         ABS(l.lcp_mean - r.lcp_mean) / (
           SQRT(
             (l.lcp_count - 1) * POWER(l.lcp_stderr, 2)
@@ -207,6 +225,7 @@ all_results AS (
 
   FROM intervals AS l INNER JOIN last_interval AS r
     ON (l.interval_name IS NOT NULL)
+  ORDER BY l.interval_start DESC
 )
 
 SELECT * FROM all_results

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -1,7 +1,5 @@
 --- description: For each of the specified intervals, report conversion rate, average LCP, FID, CLS, INP, standard error, and if there is a statistically significant difference between the latest interval and the current interval
 --- url: -
---- startdate: 2021-06-22
---- enddate: 2021-06-22
 --- timezone: UTC
 --- conversioncheckpoint: click
 --- targets: https://, http://
@@ -71,7 +69,7 @@ named_intervals AS (
   FROM (
     SELECT
       next_val AS interval_name,
-      TIMESTAMP(current_val) AS interval_start
+      TIMESTAMP(current_val, @timezone) AS interval_start
     FROM numbered_intervals
     WHERE MOD(row_num, 2) = 1
   )
@@ -91,8 +89,11 @@ alldata AS (
       @url,
       -1, # not used
       -1, # not used
-      @startdate,
-      @enddate,
+      (
+        SELECT FORMAT_TIMESTAMP("%F", interval_start, @timezone)
+        FROM named_intervals ORDER BY interval_start ASC LIMIT 1
+      ),
+      FORMAT_TIMESTAMP("%F", CURRENT_TIMESTAMP(), @timezone),
       @timezone,
       "all",
       @domainkey

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -1,0 +1,50 @@
+--- description: For each of the specified intervals, report conversion rate, average LCP, FID, CLS, INP, standard error, and if there is a statistically significant difference between the latest interval and the current interval
+--- url: -
+--- startdate: 2021-06-22
+--- enddate: 2021-06-22
+--- timezone: UTC
+--- conversioncheckpoint: click
+--- targets: https://, http://
+--- intervals: 2023-06-22,#target,2023-05-01,#mayday
+--- domainkey: secret
+WITH prefixes AS (
+  SELECT CONCAT(TRIM(prefix), "%") AS prefix
+  FROM
+    UNNEST(
+      SPLIT(@targets, ",")
+    ) AS prefix
+),
+intervals_input AS (
+  SELECT prefix AS step
+  FROM
+    UNNEST(
+      SPLIT(@intervals, ",")
+    ) AS prefix
+),
+numbered_intervals AS (
+  SELECT
+  row_num,
+  step AS current_val,
+  LEAD(step) OVER(ORDER BY row_num ASC) AS next_val
+  FROM (
+SELECT  
+  step,
+  ROW_NUMBER() OVER() AS row_num
+FROM intervals_input
+)),
+named_intervals AS (
+SELECT 
+  interval_name,
+  interval_start,
+  COALESCE(LEAD(interval_start) OVER(ORDER BY interval_start), CURRENT_TIMESTAMP()) AS interval_end
+FROM (
+SELECT 
+  next_val AS interval_name,
+  TIMESTAMP(current_val) AS interval_start,  
+FROM numbered_intervals
+WHERE MOD(row_num, 2) = 1
+)
+ORDER BY interval_start DESC)
+SELECT * FROM named_intervals
+
+# Work in progress, steal from rum-checkpoint-cwv-correlation


### PR DESCRIPTION
This PR adds a new query `rum-intervals` that allows comparing LCP and conversion rate between a number of named intervals.
For exapmle, if a significant design or implementation change has been made to a site recently, this query will allow you
to run a report that shows conversion rate and LCP for the current interval (after the redesign) and previous interval
(before the redesign). It will also compare each previous interval with the current to determine if the difference in
results is statistically significant or not.

As part of the query, you can specify
- `url`: the base URL for the analysis, as with other RUM queries without leading `https://`
- `conversioncheckpoint`: which RUM checkpoint will be counted as a successful conversion, default is `click`
- `targets`: comma-separated list of valid target prefixes that will be considered a successful conversion. Put you real click targets here, e.g. `https://example.com/signup,https://example.com/request-demo`
- `intervals`: a comma-separated list of pairs of timestamps and interval names, for instance `2023-06-22,#redesign,2023-05-01,#speedup,2023-01-01,#launch`. This will create three intervals
- `timezone`: name of a valid timezone as per Timezone DB, default is UTC
- `domainkey`: as usual

Changes:

- feat(queries): add wip query to report performance and conversion in named time intervals
- feat(rum-intervals): get intervals, and click rates for each interval
- style(sqlfluff): allow numbers in function names
- fix(rum-intervals): make query runnable
- feat(rum-intervals): report standard error and averages
- feat(rum-intervals): calculate p-value of lcp differences
- feat(rum-intervals): calculate p value for conversions, too
- fix(rum-intervals): use only date parameters from intervals list
