### PR TITLE
Fix RUM Experiments for low traffic experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,27 @@ For a full list of changes, please see the [CHANGELOG](CHANGELOG.md#300-2023-04-
 
 # Development
 
+## `dev.sh` script
+
+Running queries in development using the `bq` tool can be cumbersome, as all parameters
+in the query are required. The `dev.sh` script can be used to run queries in development
+mode and will fill out important parameters with defaut values.
+
+Start setting it up by exporting your domain key to `DOMAINKEY`, then run `dev.sh <query>`.
+
+```bash
+$ export DOMAINKEY=…
+$ sh dev.sh rum-dashboard url www.adobe.com
+```
+
+You can pass additional parameters to the query as seen above. The second (optional) parameter allows you to specify the output format, with values `pretty`, `csv`, `json`
+being supported.
+
 ## Required Environment Variables
 
 This service depends on three external services to operate:
 
 - Fastly
-- Adobe I/O Runtime (only for deployments)
 - Google Cloud Platform
 
 It is configured using a number of environment variables that are required for testing (tests that miss required variables will be skipped) and deployment (deployment will fail or be non-functional). These variables are required and this is how to set them up:

--- a/dev.sh
+++ b/dev.sh
@@ -4,8 +4,8 @@ PARAMS=$(cat src/queries/$QUERY.sql \
   | grep -e "--- [a-z]" \
   | sed 's/---//g' \
   | sed 's/^/  --parameter /' \
-  | sed -E 's/: ([0-9.]+)/:FLOAT:\1/' \
-  | sed -E 's/: ([0-9]+)/:INT64:\1/' \
+  | sed -E 's/: ([0-9]+)$/:INT64:\1/' \
+  | sed -E 's/: ([0-9.]+)$/:FLOAT:\1/' \
   | sed -E 's/: (.*)/::"\1"/' \
   | tr -d '\n')
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+QUERY=$1
+PARAMS=$(cat src/queries/$QUERY.sql \
+  | grep -e "--- [a-z]" \
+  | sed 's/---//g' \
+  | sed 's/^/  --parameter /' \
+  | sed -E 's/: ([0-9.]+)/:FLOAT:\1/' \
+  | sed -E 's/: ([0-9]+)/:INT64:\1/' \
+  | sed -E 's/: (.*)/::"\1"/' \
+  | tr -d '\n')
+
+# if second argument starts with -- use that as the format (without the --)
+# otherwise use the default format
+FORMAT="--format=sparse"
+if [[ $2 == --* ]]; then
+  FORMAT="--format" $(echo $2 | sed 's/--//')
+  shift
+fi
+
+# override --parameter domainkey::"..." with contents of DOMAINKEY env var
+if [ -n "$DOMAINKEY" ]; then
+  PARAMS=$(echo $PARAMS | sed -E "s/domainkey::\".*\"/domainkey::\"$DOMAINKEY\"/")
+fi
+
+# drop the first arg (query name)
+shift
+# override all other parameters with contents of command line args in the format parameter::value
+while [ $# -gt 0 ]; do
+  PARAMS=$(echo $PARAMS | sed -E "s/$1::\"[^\"]*\"/$1::\"$2\"/")
+  shift
+  shift
+done
+
+echo "cat src/queries/$QUERY.sql | bq query $PARAMS --use_legacy_sql=false $FORMAT" | sh
+
+

--- a/src/queries/rum-experiments.sql
+++ b/src/queries/rum-experiments.sql
@@ -126,7 +126,7 @@ conversion_rates AS (
     experimentations_summary.t5 AS t5,
     experimentations_summary.tdiff AS tdiff,
     conversions_summary.conversions / experimentations_summary.experimentations
-    AS conversion_rate
+      AS conversion_rate
   FROM experimentations_summary FULL JOIN conversions_summary
     ON
       experimentations_summary.source = conversions_summary.source
@@ -276,9 +276,10 @@ all_results AS (
       )
     ) AS p_value
   FROM conversion_rates AS l INNER JOIN
-    controls AS r ON
-    l.experiment = r.experiment
-    AND l.variant != r.variant
+    controls AS r
+    ON
+      l.experiment = r.experiment
+      AND l.variant != r.variant
   WHERE r.variant = 'control' AND l.variant != 'control'
 ),
 


### PR DESCRIPTION
In low traffic settings, a scenario could arise where for a given experiment the `control` variant was never shown.
This would cause the whole experiment to disappear from reporting. The fix in this PR is to create a synthetic row
for each experiment, fill it with the real `control` values if available or `NULL` otherwise.

This also required changing the divisions to a safe division, so that for some experiments conversion rates, etc.
will be reported as `NULL` now
