### PR TITLE
Extended Metadata in Responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ async function runExec(params, pathname, log) {
       return queryInfo(pathname, params);
     }
     const {
-      results, truncated, headers, description, requestParams,
+      results, truncated, headers, description, requestParams, responseDetails,
     } = await execute(
       params.GOOGLE_CLIENT_EMAIL,
       params.GOOGLE_PRIVATE_KEY,
@@ -49,6 +49,7 @@ async function runExec(params, pathname, log) {
       results,
       description,
       requestParams,
+      responseDetails,
       truncated,
     ), {
       status: 200,

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -491,3 +491,35 @@ FROM (
     previous_truncated_rum_by_url.pageviews DESC
 ) WHERE
   rank <= @limit OR url = "Other" OR @rising
+--- avgcls: 75th percentile value of the Cumulative Layout Shift metric in the current period
+--- avgcls_1: 75th percentile value of the CLS metric in the previous period
+--- avgfid: 75th percentile value of the First Input Delay metric in milliseconds in the current period
+--- avgfid_1: 75th percentile value of FID in the previous period
+--- avginp: 75th percentile value of the Interaction to Next Paint metric in milliseconds in the current period
+--- avginp_1: 75th percentile of INP in the previous period
+--- avglcp: 75th percentile of the Largest Contentful Paint metric in milliseconds in the current period
+--- avglcp_1: 75th percentile of LCP in the previous period
+--- clsbad: percentage of all page views where Cumulative Layout Shift is in the “needs improvement” range in the current period
+--- clsbad_1: percentage of of all page views with bad CLS in the previous period
+--- clsgood: percentage of all page views where the CLS metric is in the “good” range in the current period
+--- clsgood_1: percentage of pageviews with good CLS the the previous period
+--- fidbad: percentage of pageviews with bad FID in the current period
+--- fidbad_1: percentage of pageviews with bad FID in the previous period
+--- fidgood: percentage of pageviews with good FID in the current period
+--- fidgood_1: percentage of pageviews with good FID in the previous period
+--- inpbad: percentage of pageviews with bad INP in the current period
+--- inpbad_1: percentage of pageviews with bad INP in the previous period
+--- inpgood: percentage of pageviews with good INP in the current period
+--- inpgood_1: percentage of pageviews with bad INP in the previous period
+--- lcpbad: percentage of pageviews with bad LCP in the current period
+--- lcpbad_1: percentage of pageviews with bad LCP in the previous period
+--- lcpgood: percentage of pageviews with good LCP in the current period
+--- lcpgood_1: percentage of pageviews with good LCP in the current period
+--- pageviews: estimated number of pageviews in the current period
+--- pageviews_1: estimated number of pageviews in the previous period
+--- pageviews_diff: difference in pageviews between the current and previous period. If the parameter rising is true, then pages will be ranked according to this value
+--- rumshare: percentage of all traffic for the given domain that is going to this url in the current period
+--- rumshare_1: percentage of of all traffic in the previous domain that is going to this url in the previous period
+--- url: the URL of the page that is getting traffic
+--- url_1: the URL of the page that is getting traffic in the previous period (these last two values are always the same)
+

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -522,4 +522,3 @@ FROM (
 --- rumshare_1: percentage of of all traffic in the previous domain that is going to this url in the previous period
 --- url: the URL of the page that is getting traffic
 --- url_1: the URL of the page that is getting traffic in the previous period (these last two values are always the same)
-

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -16,7 +16,6 @@ import { auth } from './auth.js';
 
 import {
   cleanHeaderParams,
-  cleanQuery,
   getHeaderParams,
   getTrailingParams,
   loadQuery,
@@ -33,7 +32,7 @@ async function processParams(query, params) {
   const rawQuery = await loadQuery(query);
   const headerParams = getHeaderParams(rawQuery);
   const description = headerParams.description || '';
-  const loadedQuery = cleanQuery(rawQuery);
+  const loadedQuery = rawQuery;
   const requestParams = resolveParameterDiff(
     cleanHeaderParams(loadedQuery, params),
     cleanHeaderParams(loadedQuery, headerParams),

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -18,6 +18,7 @@ import {
   cleanHeaderParams,
   cleanQuery,
   getHeaderParams,
+  getTrailingParams,
   loadQuery,
   resolveParameterDiff,
 } from './util.js';
@@ -37,12 +38,14 @@ async function processParams(query, params) {
     cleanHeaderParams(loadedQuery, params),
     cleanHeaderParams(loadedQuery, headerParams),
   );
+  const responseDetails = getTrailingParams(loadedQuery);
 
   return {
     headerParams,
     description,
     loadedQuery,
     requestParams,
+    responseDetails,
   };
 }
 
@@ -62,6 +65,7 @@ export async function execute(email, key, project, query, _, params = {}) {
     description,
     loadedQuery,
     requestParams,
+    responseDetails,
   } = await processParams(query, params);
   try {
     const credentials = await auth(email, key.replace(/\\n/g, '\n'));
@@ -104,6 +108,7 @@ export async function execute(email, key, project, query, _, params = {}) {
           results,
           description,
           requestParams,
+          responseDetails,
         })))
         .on(
           'error',
@@ -119,6 +124,7 @@ export async function execute(email, key, project, query, _, params = {}) {
             results,
             description,
             requestParams,
+            responseDetails,
           });
         });
     });

--- a/src/util.js
+++ b/src/util.js
@@ -117,15 +117,6 @@ export function getTrailingParams(query) {
 }
 
 /**
- * cleans out extra parameters from query and leaves only query
- *
- * @param {string} query the content read from a query file
- */
-export function cleanQuery(query) {
-  return splitQuery(query).query;
-}
-
-/**
  * removes used up parameters from request
  *
  * @param {object} params all parameters contained in a request

--- a/src/util.js
+++ b/src/util.js
@@ -68,8 +68,8 @@ function splitQuery(query) {
   const first = lines.findIndex((line) => !line.startsWith('---'));
   // find the first SELECT statement
   const queryStart = lines.findIndex((line) => line.match(/^SELECT/i));
-  // find the first non-comment line after the query
-  const queryEnd = (lines.slice(queryStart).findIndex((line) => !line.startsWith('---')) || lines.length) + queryStart;
+  // find the first comment after the query
+  const queryEnd = lines.findIndex((_, i) => i > queryStart && !lines[i].startsWith('---'));
 
   const leading = lines
     .filter((_, i) => i < first)

--- a/src/util.js
+++ b/src/util.js
@@ -76,7 +76,7 @@ function splitQuery(query) {
     .filter((line) => line.startsWith('---'))
     .join('\n');
   const trailing = lines
-    .filter((_, i) => i > queryEnd)
+    .filter((_, i) => i > queryEnd && i > queryStart)
     .filter((line) => line.startsWith('---'))
     .join('\n');
   const queryPart = lines

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe('Index Tests', async () => {
         GOOGLE_PROJECT_ID: env.projectid,
       },
     });
-  });
+  }).timeout(10000);
 
   it('index function returns an object', async () => {
     const response = await index(new Request('https://helix-run-query.com/list-everything?limit=3', {
@@ -268,5 +268,5 @@ describe('Index Tests', async () => {
     assert.equal(text.split('\n').length, 4);
     assert.equal(text.split('\n')[0], 'client_geo_city,client_as_name,client_geo_conn_speed,client_geo_continent_code,client_geo_country_code,client_geo_gmt_offset,client_geo_latitude,client_geo_longitude,client_geo_metro_code,client_geo_postal_code,client_geo_region,client_ip_hashed,client_ip_masked,fastly_info_state,req_http_X_Ref,req_http_X_Repo,req_http_X_Static,req_http_X_Strain,req_http_X_Owner,server_datacenter,server_region,req_http_host,req_http_X_Host,req_url,req_http_X_URL,req_http_X_CDN_Request_ID,vcl_sub,time_start_usec,time_end_usec,time_elapsed_usec,resp_http_x_openwhisk_activation_id,resp_http_X_Version,req_http_Referer,req_http_User_Agent,resp_http_Content_Type,service_config,status_code');
     assert.equal(response.headers.get('content-type'), 'text/csv');
-  });
+  }).timeout(10000);
 });

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -37,6 +37,8 @@ createTargets().forEach((target) => {
         .then((response) => {
           expect(response).to.have.status(200);
           expect(response).to.have.header('Content-Type', /^application\/json/);
+          // validate the response body
+          expect(response.body.meta.data).to.have.lengthOf(44);
         })
         .catch((e) => {
           throw e;

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -38,7 +38,7 @@ createTargets().forEach((target) => {
           expect(response).to.have.status(200);
           expect(response).to.have.header('Content-Type', /^application\/json/);
           // validate the response body
-          expect(response.body.meta.data).to.have.lengthOf(44);
+          expect(response.body.meta.data).to.have.lengthOf(43);
         })
         .catch((e) => {
           throw e;

--- a/test/testQueries.js
+++ b/test/testQueries.js
@@ -41,6 +41,7 @@ describe('Test Queries', () => {
     }
     assert.ok(json.results.data);
     assert.ok(json.meta.data.filter((e) => e.name === 'domainkey').length === 0, 'domainkey should not be in requestParams');
+    assert.equal(json.meta.data.length, 44);
   }).timeout(100000);
 
   it('rum-dashboard (url auth)', async () => {

--- a/test/testSend.js
+++ b/test/testSend.js
@@ -85,7 +85,7 @@ describe('bigquery tests', async () => {
     assert.deepEqual(requestParams, { limit: 3 });
     assert.equal(description, 'good comment practices for helix queries is encouraged');
     assert.ok(results.length, 3);
-  });
+  }).timeout(20000);
 
   it('runs a query with params', async () => {
     const { results, description, requestParams } = await goodExec.execute(env.email, env.key, env.projectid, 'list-everything', service, {
@@ -95,7 +95,7 @@ describe('bigquery tests', async () => {
     assert.equal(description, 'good comment practices for helix queries is encouraged');
     assert.deepEqual(requestParams, { limit: 3 });
     assert.equal(results.length, 3);
-  });
+  }).timeout(20000);
 
   it('throws without projectid', async () => {
     try {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -14,7 +14,7 @@
 import assert from 'assert';
 import {
   cleanHeaderParams,
-  cleanQuery, cleanRequestParams, csvify,
+  cleanRequestParams, csvify,
   getHeaderParams,
   loadQuery, resolveParameterDiff,
   sshonify,
@@ -43,34 +43,6 @@ describe('testing util functions', () => {
     const EXPECTED = { 'helix-param': 'helix', 'helix-param2': 'helix2', 'helix-param3': 'helix3' };
     const ACTUAL = getHeaderParams(fakeQuery);
     assert.deepEqual(EXPECTED, ACTUAL);
-  });
-
-  it('query parameters are cleaned from query', () => {
-    const fakeQuery = `--- helix-param: helix
---- helix-param2: helix2
---- helix-param3: helix3
-#This is A random Comment
-SELECT req_url, count(req_http_X_CDN_Request_ID) AS visits, resp_http_Content_Type, status_code
-    FROM ^tablename
-    WHERE 
-      resp_http_Content_Type LIKE "text/html%" AND
-      status_code LIKE "404"
-    GROUP BY
-      req_url, resp_http_Content_Type, status_code 
-    ORDER BY visits DESC
-    LIMIT @limit`;
-
-    const EXPECTED = `SELECT req_url, count(req_http_X_CDN_Request_ID) AS visits, resp_http_Content_Type, status_code
-    FROM ^tablename
-    WHERE 
-      resp_http_Content_Type LIKE "text/html%" AND
-      status_code LIKE "404"
-    GROUP BY
-      req_url, resp_http_Content_Type, status_code 
-    ORDER BY visits DESC
-    LIMIT @limit`;
-    const ACTUAL = cleanQuery(fakeQuery);
-    assert.equal(EXPECTED, ACTUAL);
   });
 
   it('resolveParameterDiff fills in empty params with defaults', () => {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -311,9 +311,25 @@ describe('Test SSHONify', () => {
       requestParams: {
         limit: 30, interval: 1, offset: '0', url: 'blog.adobe.com', checkpoint: 'viewblock', source: '-',
       },
+      responseDetails: {
+        checkpoint: 'name of the checkpoint, i.e. the event in the page load or interaction sequence that was observed.',
+        source: 'CSS id or class name of the element that triggered the checkpoint.',
+        ids: 'number of unique RUM ids that triggered the checkpoint.',
+        pages: 'number of unique pages that triggered the checkpoint.',
+        topurl: 'most frequently observed URL that triggered the checkpoint.',
+        views: 'interpolated number of pageviews that triggered the checkpoint.',
+        actions: 'number of times the checkpoint was triggered. This may be greater than the number of unique ids if the same id triggered the checkpoint multiple times.',
+        actions_per_view: 'average number of times the checkpoint was triggered per pageview.',
+      },
       truncated: false,
     };
-    const sshon = sshonify(input.results, input.description, input.requestParams, input.truncated);
+    const sshon = sshonify(
+      input.results,
+      input.description,
+      input.requestParams,
+      input.responseDetails,
+      input.truncated,
+    );
     assert.deepStrictEqual(
       JSON.parse(sshon),
       {
@@ -359,6 +375,46 @@ describe('Test SSHONify', () => {
               name: 'source',
               type: 'request parameter',
               value: '-',
+            },
+            {
+              name: 'checkpoint',
+              type: 'response detail',
+              value: 'name of the checkpoint, i.e. the event in the page load or interaction sequence that was observed.',
+            },
+            {
+              name: 'source',
+              type: 'response detail',
+              value: 'CSS id or class name of the element that triggered the checkpoint.',
+            },
+            {
+              name: 'ids',
+              type: 'response detail',
+              value: 'number of unique RUM ids that triggered the checkpoint.',
+            },
+            {
+              name: 'pages',
+              type: 'response detail',
+              value: 'number of unique pages that triggered the checkpoint.',
+            },
+            {
+              name: 'topurl',
+              type: 'response detail',
+              value: 'most frequently observed URL that triggered the checkpoint.',
+            },
+            {
+              name: 'views',
+              type: 'response detail',
+              value: 'interpolated number of pageviews that triggered the checkpoint.',
+            },
+            {
+              name: 'actions',
+              type: 'response detail',
+              value: 'number of times the checkpoint was triggered. This may be greater than the number of unique ids if the same id triggered the checkpoint multiple times.',
+            },
+            {
+              name: 'actions_per_view',
+              type: 'response detail',
+              value: 'average number of times the checkpoint was triggered per pageview.',
             },
           ],
           columns: [
@@ -461,7 +517,13 @@ describe('Test SSHONify', () => {
       },
       truncated: false,
     };
-    const sshon = sshonify(input.results, input.description, input.requestParams, input.truncated);
+    const sshon = sshonify(
+      input.results,
+      input.description,
+      input.requestParams,
+      {},
+      input.truncated,
+    );
     assert.deepStrictEqual(
       JSON.parse(sshon),
       {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -16,6 +16,7 @@ import {
   cleanHeaderParams,
   cleanRequestParams, csvify,
   getHeaderParams,
+  getTrailingParams,
   loadQuery, resolveParameterDiff,
   sshonify,
   validParamCheck,
@@ -25,6 +26,11 @@ describe('testing util functions', () => {
   it('loadQuery loads a query', async () => {
     const result = await loadQuery('rum-dashboard');
     assert.ok(result.match(/select/i));
+  });
+
+  it('loadQuery works with trailing parameters', async () => {
+    const result = await loadQuery('rum-dashboard');
+    assert.equal(Object.keys(getTrailingParams(result)).length, 31);
   });
 
   it('loadQuery throws with bad query file', async () => {


### PR DESCRIPTION
This PR provides the ability to return column descriptions in the `meta` worksheet of the response.

As a query developer, you add colon-separated column names and their description at the bottom of the query SQL, similar to the parameter description at the top of the SQL file. The query engine will then pick this up and return it as part of the response object, making deciphering the responses a bit easier.