### PR TITLE
Totalfix

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -162,8 +162,8 @@ export function sshonify(results, description, requestParams, truncated) {
     ':version': 3,
     results: {
       limit: Math.max(requestParams.limit || 1, results.length),
-      offset: requestParams.offset || 0,
-      total: requestParams.offset || 0 + results.length + (truncated ? 1 : 0),
+      offset: parseInt(requestParams.offset) || 0,
+      total: results.length + (truncated ? 1 : 0),
       data: results,
       columns: Object.keys(results[0] || {}),
     },

--- a/src/util.js
+++ b/src/util.js
@@ -163,7 +163,7 @@ export function sshonify(results, description, requestParams, truncated) {
     results: {
       limit: Math.max(requestParams.limit || 1, results.length),
       offset: parseInt(requestParams.offset, 10) || 0,
-      total: results.length + (truncated ? 1 : 0),
+      total: results.length + Number(truncated),
       data: results,
       columns: Object.keys(results[0] || {}),
     },

--- a/src/util.js
+++ b/src/util.js
@@ -162,7 +162,7 @@ export function sshonify(results, description, requestParams, truncated) {
     ':version': 3,
     results: {
       limit: Math.max(requestParams.limit || 1, results.length),
-      offset: parseInt(requestParams.offset) || 0,
+      offset: parseInt(requestParams.offset, 10) || 0,
       total: results.length + (truncated ? 1 : 0),
       data: results,
       columns: Object.keys(results[0] || {}),

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -372,8 +372,8 @@ describe('Test SSHONify', () => {
         },
         results: {
           limit: 30,
-          offset: '0',
-          total: '0',
+          offset: 0,
+          total: 0,
           columns: [
             'checkpoint',
             'source',
@@ -520,8 +520,8 @@ describe('Test SSHONify', () => {
         },
         results: {
           limit: 30,
-          offset: '0',
-          total: '0',
+          offset: 0,
+          total: 0,
           columns: [],
           data: [],
         },

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -373,7 +373,7 @@ describe('Test SSHONify', () => {
         results: {
           limit: 30,
           offset: 0,
-          total: 0,
+          total: 30,
           columns: [
             'checkpoint',
             'source',


### PR DESCRIPTION
Fix total count -- previously it only showed the total results if offset was not provided, else it showed the value of offset.

Return type of offset and total is now int.

This change is fully independent of the pagination request.  The total field will never exceed limit and should not be interpreted as the total if there were no limit.

## Related Issues
#911 
