### PR TITLE
support query folders using standard path separator (/)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import { logger } from '@adobe/helix-universal-logger';
 import { Response } from '@adobe/fetch';
 import bodyData from '@adobe/helix-shared-body-data';
 import { execute, queryInfo } from './sendquery.js';
-import { cleanRequestParams, csvify, sshonify } from './util.js';
+import { cleanRequestParams, csvify, sshonify, extractQueryPath } from './util.js';
 
 async function runExec(params, pathname, log) {
   try {
@@ -78,16 +78,7 @@ async function run(request, context) {
   params.GOOGLE_PROJECT_ID = context.env.GOOGLE_PROJECT_ID;
 
   // nested folder support
-  // the following pathname patterns all work correctly with the regular expression
-  // /helix-services/run-query/file
-  // /helix-services/run-query@v1/file
-  // /helix-services/run-query@v2/folder/file
-  // /helix-services/run-query@ci123/file
-  // /helix-services/run-query@ci456/folder/file
-  // /helix-services/run-query/ci789/file
-  // /helix-services/run-query/ci123/folder/file
-  // /helix-services/run-query@v3/folder/folder/file
-  return runExec(params, pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)\d+)*\//g, ''), context.log);
+  return runExec(params, extractQueryPath(pathname), context.log);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,17 @@ async function run(request, context) {
   params.GOOGLE_PRIVATE_KEY = context.env.GOOGLE_PRIVATE_KEY;
   params.GOOGLE_PROJECT_ID = context.env.GOOGLE_PROJECT_ID;
 
-  return runExec(params, pathname.split('/').pop(), context.log);
+  // nested folder support
+  // the following pathname patterns all work correctly with the regular expression
+  // /helix-services/run-query/file
+  // /helix-services/run-query@v1/file
+  // /helix-services/run-query@v2/folder/file
+  // /helix-services/run-query@ci123/file
+  // /helix-services/run-query@ci456/folder/file
+  // /helix-services/run-query/ci789/file
+  // /helix-services/run-query/ci123/folder/file
+  // /helix-services/run-query@v3/folder/folder/file
+  return runExec(params, pathname.replace(/^\/helix-services\/run-query((\@|\/)(ci|v)\d+)*\//g, ''), context.log);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,9 @@ import { logger } from '@adobe/helix-universal-logger';
 import { Response } from '@adobe/fetch';
 import bodyData from '@adobe/helix-shared-body-data';
 import { execute, queryInfo } from './sendquery.js';
-import { cleanRequestParams, csvify, sshonify, extractQueryPath } from './util.js';
+import {
+  cleanRequestParams, csvify, sshonify, extractQueryPath,
+} from './util.js';
 
 async function runExec(params, pathname, log) {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ async function run(request, context) {
   // /helix-services/run-query/ci789/file
   // /helix-services/run-query/ci123/folder/file
   // /helix-services/run-query@v3/folder/folder/file
-  return runExec(params, pathname.replace(/^\/helix-services\/run-query((\@|\/)(ci|v)\d+)*\//g, ''), context.log);
+  return runExec(params, pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)\d+)*\//g, ''), context.log);
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -114,6 +114,24 @@ export function validParamCheck(params) {
 }
 
 /**
+ * pulls the query path from the URL which allows for organization by folder
+ * @param {string} pathname 
+ * @returns path under /src/queries where query is found
+ */
+export function extractQueryPath(pathname) {
+  // TODO add automated tests for the regular expression to validate at least the below patterns
+  // /helix-services/run-query/file
+  // /helix-services/run-query@v1/file
+  // /helix-services/run-query@v2/folder/file
+  // /helix-services/run-query@ci123/file
+  // /helix-services/run-query@ci456/folder/file
+  // /helix-services/run-query/ci789/file
+  // /helix-services/run-query/ci123/folder/file
+  // /helix-services/run-query@v3/folder/folder/file
+  return pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)\d+)*\//g, '');
+}
+
+/**
  * fills in missing query parameters (if any) with defaults from query file
  * @param {object} params provided parameters
  * @param {object} defaults default parameters in query file

--- a/src/util.js
+++ b/src/util.js
@@ -119,15 +119,6 @@ export function validParamCheck(params) {
  * @returns path under /src/queries where query is found
  */
 export function extractQueryPath(pathname) {
-  // TODO add automated tests for the regular expression to validate at least the below patterns
-  // /helix-services/run-query/file
-  // /helix-services/run-query@v1/file
-  // /helix-services/run-query@v2/folder/file
-  // /helix-services/run-query@ci123/file
-  // /helix-services/run-query@ci456/folder/file
-  // /helix-services/run-query/ci789/file
-  // /helix-services/run-query/ci123/folder/file
-  // /helix-services/run-query@v3/folder/folder/file
   return pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)\d+)*\//g, '');
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -115,7 +115,7 @@ export function validParamCheck(params) {
 
 /**
  * pulls the query path from the URL which allows for organization by folder
- * @param {string} pathname 
+ * @param {string} pathname path which needs to be parsed
  * @returns path under /src/queries where query is found
  */
 export function extractQueryPath(pathname) {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -18,10 +18,21 @@ import {
   getHeaderParams,
   loadQuery, resolveParameterDiff,
   sshonify,
-  validParamCheck,
+  validParamCheck, extractQueryPath,
 } from '../src/util.js';
 
 describe('testing util functions', () => {
+  it('extractQueryPath parses a run-query path to find the folder/file for a query', async () => {
+    assert.equal(extractQueryPath('/helix-services/run-query/file'), 'file');
+    assert.equal(extractQueryPath('/helix-services/run-query@v1/file'), 'file');
+    assert.equal(extractQueryPath('/helix-services/run-query@v2/folder/file'), 'folder/file');
+    assert.equal(extractQueryPath('/helix-services/run-query@ci123/file'), 'file');
+    assert.equal(extractQueryPath('/helix-services/run-query@ci456/folder/file'), 'folder/file');
+    assert.equal(extractQueryPath('/helix-services/run-query/ci789/file'), 'file');
+    assert.equal(extractQueryPath('/helix-services/run-query/ci123/folder/file'), 'folder/file');
+    assert.equal(extractQueryPath('/helix-services/run-query@v3/folder/folder/file'), 'folder/folder/file');
+  });
+
   it('loadQuery loads a query', async () => {
     const result = await loadQuery('rum-dashboard');
     assert.ok(result.match(/select/i));


### PR DESCRIPTION
Added support for folders under /src/queries to enable better organization.  Supports a variety of URL formats as described in the comments of the first commit.
