### PR TITLE
query folders - allow semantic version url used by postdeploy test

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -147,7 +147,13 @@ export function validParamCheck(params) {
  * @returns path under /src/queries where query is found
  */
 export function extractQueryPath(pathname) {
-  return pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)\d+)*\//g, '');
+  // remove /helix-services/run-query
+  // optionally followed by @ or /
+  // then optionally ci or v
+  // then any combination of digits and . char
+  // and finally another / slash
+  // everything after that should be kept
+  return pathname.replace(/^\/helix-services\/run-query((@|\/)(ci|v)*[0-9.]+)*\//, '');
 }
 
 /**

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -32,6 +32,7 @@ describe('testing util functions', () => {
     assert.equal(extractQueryPath('/helix-services/run-query/ci789/file'), 'file');
     assert.equal(extractQueryPath('/helix-services/run-query/ci123/folder/file'), 'folder/file');
     assert.equal(extractQueryPath('/helix-services/run-query@v3/folder/folder/file'), 'folder/folder/file');
+    assert.equal(extractQueryPath('/helix-services/run-query/3.3.0/folder/folder/file'), 'folder/folder/file');
   });
 
   it('loadQuery loads a query', async () => {


### PR DESCRIPTION
adjusted the query folder regular expression and added a test for another valid path format:
`/helix-services/run-query/3.3.0/folder/folder/file`
