### PR TITLE
domainkey-related queries - check authorization, list domains, update IMS org

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
       "src/queries/rum-sources.sql",
       "src/queries/rum-targets.sql",
       "src/queries/dash/auth-all-domains.sql",
-      "src/queries/dash/domain-list.sql"
+      "src/queries/dash/domain-list.sql",
+      "src/queries/dash/update-domain-info.sql"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
       "src/queries/rum-sources-targets.sql",
       "src/queries/rum-sources.sql",
       "src/queries/rum-targets.sql",
-      "src/queries/dash/auth-all-domains.sql"
+      "src/queries/dash/auth-all-domains.sql",
+      "src/queries/dash/domain-list.sql"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
       "src/queries/rum-pageviews.sql",
       "src/queries/rum-sources-targets.sql",
       "src/queries/rum-sources.sql",
-      "src/queries/rum-targets.sql"
+      "src/queries/rum-targets.sql",
+      "src/queries/dash/auth-all-domains.sql"
     ]
   }
 }

--- a/src/queries/dash/auth-all-domains.sql
+++ b/src/queries/dash/auth-all-domains.sql
@@ -4,17 +4,7 @@
 --- timezone: UTC
 --- domainkey: secret
 
-SELECT COALESCE(
-  (
-    SELECT IF(hostname_prefix = '', true, false)
-    FROM
-      `helix-225321.helix_reporting.domain_keys`
-    WHERE
-      key_bytes = SHA512(@domainkey)
-      AND (
-        revoke_date IS NULL
-        OR revoke_date > CURRENT_DATE(@timezone)
-      )
-  ),
-  false
-) AS auth
+SELECT
+  read,
+  write
+FROM helix_reporting.DOMAINKEY_PRIVS_ALL(@domainkey, @timezone)

--- a/src/queries/dash/auth-all-domains.sql
+++ b/src/queries/dash/auth-all-domains.sql
@@ -1,0 +1,20 @@
+--- description: Determine if a given domainkey has access to all domains
+--- Access-Control-Allow-Origin: *
+--- Cache-Control: max-age=3600
+--- timezone: UTC
+--- domainkey: secret
+
+SELECT COALESCE(
+  (
+    SELECT IF(hostname_prefix = '', true, false)
+    FROM
+      `helix-225321.helix_reporting.domain_keys`
+    WHERE
+      key_bytes = SHA512(@domainkey)
+      AND (
+        revoke_date IS NULL
+        OR revoke_date > CURRENT_DATE(@timezone)
+      )
+  ),
+  false
+) AS auth

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -26,7 +26,7 @@ WITH pvs AS (
     )
   WHERE
     hostname != ''
-    AND hostname != '127.0.0.1'
+    AND NOT REGEXP_CONTAINS(hostname, r'^\d+\.\d+\.\d+\.\d+$')
     AND hostname NOT LIKE 'localhost%'
     AND hostname NOT LIKE '%.hlx.page'
     AND hostname NOT LIKE '%.hlx3.page'
@@ -84,5 +84,5 @@ SELECT
 FROM domains
 WHERE
   total_visits >= 1000
-  AND DATE(last_visit) > (CURRENT_DATE() - 90)
+  AND DATE(last_visit) > (CURRENT_DATE() - 60)
 ORDER BY total_visits DESC, current_month_visits DESC, first_visit DESC

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -30,10 +30,11 @@ WITH pvs AS (
     AND hostname NOT LIKE 'localhost%'
     AND hostname NOT LIKE '%.hlx.page'
     AND hostname NOT LIKE '%.hlx3.page'
-    AND (hostname NOT LIKE '%.hlx.live' AND hostname != 'www.hlx.live')
+    AND hostname NOT LIKE '%.hlx.live'
     AND hostname NOT LIKE '%.helix3.dev'
     AND hostname NOT LIKE '%.sharepoint.com'
     AND hostname NOT LIKE '%.google.com'
+    OR hostname = 'www.hlx.live'
   GROUP BY month, weight, hostname
 ),
 

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -76,13 +76,18 @@ domains AS (
 )
 
 SELECT
-  hostname,
-  first_visit,
-  last_visit,
-  current_month_visits,
-  total_visits
-FROM domains
+  a.hostname,
+  b.ims_org_id,
+  a.first_visit,
+  a.last_visit,
+  a.current_month_visits,
+  a.total_visits
+FROM domains AS a
+LEFT JOIN
+  helix_reporting.domain_info AS b
+  ON
+    a.hostname = b.domain
 WHERE
-  total_visits >= 1000
-  AND DATE(last_visit) > (CURRENT_DATE() - 60)
-ORDER BY total_visits DESC, current_month_visits DESC, first_visit DESC
+  a.total_visits >= 1000
+  AND DATE(a.last_visit) > (CURRENT_DATE() - 60)
+ORDER BY a.total_visits DESC, a.current_month_visits DESC

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -1,0 +1,87 @@
+--- description: List of domains along with some summary data.
+--- Access-Control-Allow-Origin: *
+--- Cache-Control: max-age=3600
+--- timezone: UTC
+--- device: all
+--- domainkey: secret
+
+WITH pvs AS (
+  SELECT
+    weight,
+    REGEXP_REPLACE(hostname, r'www.', '') AS hostname,
+    COUNT(DISTINCT id) AS ids,
+    FORMAT_DATE('%Y-%b', time) AS month,
+    MIN(time) AS first_visit,
+    MAX(time) AS last_visit
+  FROM
+    helix_rum.EVENTS_V3(
+      '-',
+      -1,
+      -1,
+      '2020-01-01',
+      '2099-12-31',
+      @timezone,
+      @device,
+      @domainkey
+    )
+  WHERE
+    hostname != ''
+    AND hostname != '127.0.0.1'
+    AND hostname NOT LIKE 'localhost%'
+    AND hostname NOT LIKE '%.hlx.page'
+    AND hostname NOT LIKE '%.hlx3.page'
+    AND hostname NOT LIKE '%.hlx.live'
+    AND hostname NOT LIKE '%.helix3.dev'
+    AND hostname NOT LIKE '%.sharepoint.com'
+    AND hostname NOT LIKE '%.google.com'
+  GROUP BY month, weight, hostname
+),
+
+month_pvs AS (
+  SELECT
+    hostname,
+    month,
+    SUM(weight * ids) AS estimated_pvs,
+    FORMAT_DATE('%F', MIN(first_visit)) AS first_visit,
+    FORMAT_DATE('%F', MAX(last_visit)) AS last_visit
+  FROM pvs
+  GROUP BY hostname, month
+),
+
+total_pvs AS (
+  SELECT
+    hostname,
+    FORMAT_DATE('%F', MIN(first_visit)) AS first_visit,
+    FORMAT_DATE('%F', MAX(last_visit)) AS last_visit,
+    SUM(weight * ids) AS estimated_pvs
+  FROM pvs
+  GROUP BY hostname
+),
+
+domains AS (
+  SELECT
+    a.hostname,
+    a.first_visit,
+    a.last_visit,
+    b.estimated_pvs AS current_month_visits,
+    a.estimated_pvs AS total_visits
+  FROM total_pvs AS a
+  LEFT JOIN
+    month_pvs AS b
+    ON
+      a.hostname = b.hostname AND b.month = FORMAT_DATE('%Y-%b', CURRENT_DATE())
+  GROUP BY
+    a.hostname, a.first_visit, a.last_visit, a.estimated_pvs, b.estimated_pvs
+)
+
+SELECT
+  hostname,
+  first_visit,
+  last_visit,
+  current_month_visits,
+  total_visits
+FROM domains
+WHERE
+  total_visits >= 1000
+  AND DATE(last_visit) > (CURRENT_DATE() - 90)
+ORDER BY total_visits DESC, current_month_visits DESC, first_visit DESC

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -30,7 +30,7 @@ WITH pvs AS (
     AND hostname NOT LIKE 'localhost%'
     AND hostname NOT LIKE '%.hlx.page'
     AND hostname NOT LIKE '%.hlx3.page'
-    AND hostname NOT LIKE '%.hlx.live'
+    AND (hostname NOT LIKE '%.hlx.live' AND hostname != 'www.hlx.live')
     AND hostname NOT LIKE '%.helix3.dev'
     AND hostname NOT LIKE '%.sharepoint.com'
     AND hostname NOT LIKE '%.google.com'

--- a/src/queries/dash/update-domain-info.sql
+++ b/src/queries/dash/update-domain-info.sql
@@ -1,7 +1,7 @@
 --- description: Allow privileged user to insert/update domain_info table
 --- Access-Control-Allow-Origin: *
---- url:
---- ims:
+--- url: -
+--- ims: -
 --- timezone: UTC
 --- domainkey: secret
 

--- a/src/queries/dash/update-domain-info.sql
+++ b/src/queries/dash/update-domain-info.sql
@@ -1,0 +1,8 @@
+--- description: Allow privileged user to insert/update domain_info table
+--- Access-Control-Allow-Origin: *
+--- url:
+--- ims:
+--- timezone: UTC
+--- domainkey: secret
+
+CALL `helix_reporting.UPDATE_DOMAIN_INFO` (@domainkey, @timezone, @url, @ims);

--- a/src/queries/dash/update-domain-info.sql
+++ b/src/queries/dash/update-domain-info.sql
@@ -5,4 +5,12 @@
 --- timezone: UTC
 --- domainkey: secret
 
-CALL `helix_reporting.UPDATE_DOMAIN_INFO` (@domainkey, @timezone, @url, @ims);
+DECLARE result STRING;
+CALL `helix_reporting.UPDATE_DOMAIN_INFO` (
+  @domainkey,
+  @timezone,
+  @url,
+  @ims,
+  result
+);
+SELECT result;


### PR DESCRIPTION
This PR includes 3 new run-queries, and sql for a new table function and new stored procedure.
- auth-all-domain.sql (which references DOMAINKEY_PRIVS_ALL table function) used to determine if a given domainkey has global domain privileges, both read and write
- domain-list.sql used to show domains which meet a certain threshold of RUM traffic
- update-domain-info.sql (which references UPDATE_DOMAIN_INFO stored procedure) which allows privileged users to add IMS org to our domain_info mapping table

## Related Issues
#936 
