### PR TITLE
allow rotate-domainkeys to be called from website

### DIFF
--- a/src/queries/rotate-domainkeys.sql
+++ b/src/queries/rotate-domainkeys.sql
@@ -1,4 +1,5 @@
 --- description: Rotate domain keys
+--- Access-Control-Allow-Origin: *
 --- timezone: UTC
 --- url: -
 --- device: all

--- a/src/queries/rotate-domainkeys.sql
+++ b/src/queries/rotate-domainkeys.sql
@@ -23,7 +23,7 @@ IF EXISTS (
     AND readonly = FALSE
 ) THEN
   SET newkey = IF(@newkey = "-", GENERATE_UUID(), @newkey);
-  CALL helix_rum . ROTATE_DOMAIN_KEYS(
+  CALL helix_rum . ROTATE_DOMAIN_KEYS( -- noqa: PRS
     @domainkey,
     IF(@url = "-", "", @url),
     @timezone,


### PR DESCRIPTION
Franklin Dashboard can expose a domainkey generate feature, but first this run-query needs to be available to be called from it.
