### PR TITLE
new query - monthly totals across sites, pivot table

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
       "src/queries/rum-experiments.sql",
       "src/queries/rum-intervals.sql",
       "src/queries/rum-pageviews.sql",
+      "src/queries/rum-pageviews-pivot.sql",
       "src/queries/rum-sources-targets.sql",
       "src/queries/rum-sources.sql",
       "src/queries/rum-targets.sql"

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -51,8 +51,8 @@ WITH pvs AS (
   FROM
     helix_rum.PAGEVIEWS_V3(
       '%s',
-      %d,
-      %d,
+      %s,
+      %s,
       '',
       '',
       '%s',

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -59,8 +59,8 @@ WITH pvs AS (
   FROM
     helix_rum.PAGEVIEWS_V3(
       @url,
-      @offset,
-      @interval,
+      CAST(@offset AS INT64),
+      CAST(@interval AS INT64),
       '',
       '',
       @timezone,

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -1,0 +1,104 @@
+--- description: Get monthly page views for a site according to Helix RUM data
+--- Authorization: none
+--- Access-Control-Allow-Origin: *
+--- interval: 365
+--- offset: 0
+--- url: -
+--- timezone: UTC
+--- device: all
+--- domainkey: secret
+
+-- prepare two strings to insert into query below
+-- pivot command requires specific values, not dynamic results
+DECLARE months12 STRING;
+DECLARE months3 STRING;
+
+SET months12 = (
+  SELECT
+    CONCAT(
+      '("',
+      STRING_AGG(DISTINCT FORMAT_DATE('%Y-%b', alldays), '", "'),
+      '")'
+    )
+  FROM
+    UNNEST(
+      GENERATE_DATE_ARRAY(CURRENT_DATE('UTC') - 365, CURRENT_DATE('UTC') - 1)
+    ) AS alldays
+  WHERE FORMAT_DATE('%d', alldays) = '01'
+);
+SET months3 = (
+  SELECT
+    CONCAT(
+      '("',
+      STRING_AGG(DISTINCT FORMAT_DATE('%Y-%b', alldays), '", "'),
+      '")'
+    )
+  FROM
+    UNNEST(
+      GENERATE_DATE_ARRAY(CURRENT_DATE('UTC') - 90, CURRENT_DATE('UTC') - 1)
+    ) AS alldays
+);
+
+-- workaround to put dynamic list of specific values into PIVOT command
+-- otherwise month/year would need to be hardcoded
+EXECUTE IMMEDIATE format( -- noqa: PRS
+"""
+WITH pvs AS (
+  SELECT
+    SUM(pageviews) AS pageviews,
+    REGEXP_REPLACE(hostname, r'^www.', '') AS hostname,
+    FORMAT_DATE('%%Y-%%b', time) AS month
+  FROM
+    helix_rum.PAGEVIEWS_V3(
+      @url,
+      @offset,
+      @interval,
+      '',
+      '',
+      @timezone,
+      @device,
+      @domainkey
+    )
+  WHERE
+    hostname != ''
+    AND NOT REGEXP_CONTAINS(hostname, r'^\\d+\\.\\d+\\.\\d+\\.\\d+$') -- IP addresses
+    AND hostname NOT LIKE 'localhost%%'
+    AND hostname NOT LIKE '%%.hlx.page'
+    AND hostname NOT LIKE '%%.hlx3.page'
+    AND hostname NOT LIKE '%%.hlx.live'
+    AND hostname NOT LIKE '%%.helix3.dev'
+    AND hostname NOT LIKE '%%.sharepoint.com'
+    AND hostname NOT LIKE '%%.google.com'
+    AND hostname NOT LIKE '%%.edison.pfizer' -- not live
+    AND hostname NOT LIKE '%%.web.pfizer'
+    OR hostname = 'www.hlx.live'
+  GROUP BY month, hostname
+),
+
+total_pvs AS (
+  SELECT
+    hostname,
+    month,
+    SUM(pageviews) AS estimated_pvs
+  FROM pvs
+  GROUP BY hostname, month
+),
+
+grid AS (
+  SELECT * FROM
+  (
+    SELECT hostname, month, estimated_pvs
+    FROM total_pvs
+  )
+  PIVOT
+  (
+    ANY_VALUE(estimated_pvs)
+    FOR month IN %s
+  )
+)
+
+SELECT *
+FROM grid
+WHERE hostname IN (SELECT DISTINCT hostname FROM total_pvs WHERE month IN %s AND estimated_pvs >= 1000)
+ORDER BY hostname
+""", months12, months3);

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -22,7 +22,10 @@ SET months12 = (
     )
   FROM
     UNNEST(
-      GENERATE_DATE_ARRAY(CURRENT_DATE(@timezone) - 365, CURRENT_DATE(@timezone) - 1)
+      GENERATE_DATE_ARRAY(
+        CURRENT_DATE(@timezone) - 365,
+        CURRENT_DATE(@timezone) - 1
+      )
     ) AS alldays
   WHERE FORMAT_DATE('%d', alldays) = '01'
 );
@@ -35,7 +38,10 @@ SET months3 = (
     )
   FROM
     UNNEST(
-      GENERATE_DATE_ARRAY(CURRENT_DATE(@timezone) - 90, CURRENT_DATE(@timezone) - 1)
+      GENERATE_DATE_ARRAY(
+        CURRENT_DATE(@timezone) - 90,
+        CURRENT_DATE(@timezone) - 1
+      )
     ) AS alldays
 );
 

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -50,14 +50,14 @@ WITH pvs AS (
     FORMAT_DATE('%%Y-%%b', time) AS month
   FROM
     helix_rum.PAGEVIEWS_V3(
-      @url,
-      @offset,
-      @interval,
+      '%s',
+      %d,
+      %d,
       '',
       '',
-      @timezone,
-      @device,
-      @domainkey
+      '%s',
+      '%s',
+      '%s'
     )
   WHERE
     hostname != ''
@@ -101,4 +101,4 @@ SELECT *
 FROM grid
 WHERE hostname IN (SELECT DISTINCT hostname FROM total_pvs WHERE month IN %s AND estimated_pvs >= 1000)
 ORDER BY hostname
-""", months12, months3);
+""", @url, @offset, @interval, @timezone, @device, @domainkey, months12, months3);

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -22,7 +22,7 @@ SET months12 = (
     )
   FROM
     UNNEST(
-      GENERATE_DATE_ARRAY(CURRENT_DATE('UTC') - 365, CURRENT_DATE('UTC') - 1)
+      GENERATE_DATE_ARRAY(CURRENT_DATE(@timezone) - 365, CURRENT_DATE(@timezone) - 1)
     ) AS alldays
   WHERE FORMAT_DATE('%d', alldays) = '01'
 );
@@ -35,7 +35,7 @@ SET months3 = (
     )
   FROM
     UNNEST(
-      GENERATE_DATE_ARRAY(CURRENT_DATE('UTC') - 90, CURRENT_DATE('UTC') - 1)
+      GENERATE_DATE_ARRAY(CURRENT_DATE(@timezone) - 90, CURRENT_DATE(@timezone) - 1)
     ) AS alldays
 );
 


### PR DESCRIPTION
Several people have asked in the past weeks to see traffic numbers across sites.  This new query shows the past 12 month total estimated page views per domain where at least one of the past 3 months has >= 1000 estimated page views.  The syntax is a bit different than most queries due to the PIVOT command accepting dynamic column names.  EXECUTE IMMEDIATE is used to convert a dynamic list into a static string, and variable/param replacement are different.
