### PR TITLE
feat(domainkey): add metadata, revoke w/o create

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
       "src/queries/dev-urls.sql",
       "src/queries/ee-score.sql",
       "src/queries/guess-hostname.sql",
+      "src/queries/revoke-domainkey.sql",
       "src/queries/rotate-domainkeys.sql",
       "src/queries/rum-checkpoint-cwv-correlation.sql",
       "src/queries/rum-checkpoint-urls.sql",

--- a/src/queries/revoke-domainkey.sql
+++ b/src/queries/revoke-domainkey.sql
@@ -20,7 +20,7 @@ IF EXISTS (
     AND readonly = FALSE
 ) THEN
   SET revokekey = IF(@revokekey = "-", "", @revokekey);
-  CALL helix_reporting . REVOKE_DOMAIN_KEY( -- noqa: PRS
+  CALL helix_reporting.REVOKE_DOMAIN_KEY( -- noqa: PRS, LT01
     @revokekey,
     IF(@url = "-", "", @url),
     @timezone,

--- a/src/queries/rotate-domainkeys.sql
+++ b/src/queries/rotate-domainkeys.sql
@@ -23,7 +23,7 @@ IF EXISTS (
     AND readonly = FALSE
 ) THEN
   SET newkey = IF(@newkey = "-", GENERATE_UUID(), @newkey);
-  CALL helix_reporting . ROTATE_DOMAIN_KEYS( -- noqa: PRS
+  CALL helix_reporting.ROTATE_DOMAIN_KEYS( -- noqa: PRS, LT01
     @domainkey,
     IF(@url = "-", "", @url),
     @timezone,


### PR DESCRIPTION
Outside of the PR:
- added additional metadata fields (create_date, parent_key_bytes, note) to helix_reporting.domain_keys
- added ROTATE_DOMAIN_KEYS stored proc to helix_reporting dataset and added note param
- updated helix_rum.ROTATE_DOMAIN_KEYS to populate note field with "legacy" until such time we remove from that dataset -- probably by EOY if we no longer see any where note=legacy it will be safe to delete the old stored proc from helix_rum.
- added helix_reporting.REVOKE_DOMAIN_KEY stored proc which revokes a domain key without replacing it

Inside the PR:
- updated rotate-domainkeys run-query to point to replacement stored proc in new dataset, add note param
- new run-query for revoke

Two additional metadata fields are auto-populated by the stored proc without any related signature change -- create_date and parent_key_bytes -- since that info is already available.  These updates allow us to have greater visibility into domain key management, and greater functionality from command-line (and future UI) without needing direct BQ table access.
