### PR TITLE
[EDS] pageviews min cwv count threshold

### DIFF
--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -34,7 +34,7 @@ current_rum_by_id AS (
     id,
     ANY_VALUE(host) AS host,
     ANY_VALUE(user_agent) AS user_agent,
-    MAX(url) AS url,
+    ANY_VALUE(url) AS url,
     MAX(CASE
       WHEN @cwv_type = "lcp" THEN lcp
       WHEN @cwv_type = "cls" THEN cls

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -9,7 +9,7 @@
 --- url: -
 --- cwv_type: lcp
 --- cwv_count_threshold: 100
---- sampling_noise_factor: 1000
+--- avg_daily_pageviews_factor: 1000
 --- domainkey: secret
 
 
@@ -89,7 +89,7 @@ url_above_cwv_count_threshold AS (
     ON filtered_data.url = cru.url
   WHERE
     cwv_count > @cwv_count_threshold
-    AND (ce.events * cru.weight) > @interval * @sampling_noise_factor
+    AND (ce.events * cru.weight) > @interval * @avg_daily_pageviews_factor
 )
 
 SELECT

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -33,7 +33,7 @@ current_rum_by_id AS (
   SELECT
     id,
     ANY_VALUE(host) AS host,
-    MAX(user_agent) AS user_agent,
+    ANY_VALUE(user_agent) AS user_agent,
     MAX(url) AS url,
     MAX(CASE
       WHEN @cwv_type = "lcp" THEN lcp

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -41,7 +41,7 @@ current_rum_by_id AS (
       WHEN @cwv_type = "fid" THEN fid
       WHEN @cwv_type = "inp" THEN inp
     END) AS core_web_vital,
-    MAX(referer) AS referer,
+    ANY_VALUE(referer) AS referer,
     MAX(weight) AS weight
   FROM current_data
   WHERE

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -32,7 +32,7 @@ WITH current_data AS (
 current_rum_by_id AS (
   SELECT
     id,
-    MAX(host) AS host,
+    ANY_VALUE(host) AS host,
     MAX(user_agent) AS user_agent,
     MAX(url) AS url,
     MAX(CASE

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -1,0 +1,94 @@
+--- description: Get pageviews for a given URL or domain having a Core Web Vital events count above a given threshold
+--- Access-Control-Allow-Origin: *
+--- interval: 30
+--- offset: 0
+--- startdate: 2022-02-01
+--- enddate: 2022-05-28
+--- timezone: UTC
+--- device: all
+--- url: -
+--- owner: -
+--- repo: -
+--- cwv_type: lcp
+--- cwv_count_threshold: 100
+--- sampling_noise_factor: 1000
+--- domainkey: secret
+WITH current_data AS (
+  SELECT * FROM
+    helix_rum.EVENTS_V3(
+      @url, -- domain or URL
+      CAST(@offset AS INT64), -- not used, offset in days from today
+      CAST(@interval AS INT64), -- interval in days to consider
+      @startdate, -- not used, start date
+      @enddate, -- not used, end date
+      @timezone, -- timezone
+      @device, -- device class
+      @domainkey
+    )
+) 
+current_rum_by_id AS (
+  SELECT
+    id,
+    MAX(host) AS host,
+    MAX(user_agent) AS user_agent,
+    MAX(url) as url,
+    MAX(CASE WHEN @cwv_type = "lcp" THEN lcp
+        WHEN @cwv_type = "cls" THEN cls
+        WHEN @cwv_type = "fid" THEN fid
+        WHEN @cwv_type = "inp" THEN inp
+    ELSE NULL END) AS core_web_vital,
+    MAX(referer) AS referer,
+    MAX(weight) AS weight
+  FROM current_data
+  WHERE
+    url LIKE CONCAT("https://", @url, "%")
+     OR url LIKE CONCAT(
+      "https://%", @repo, "--", @owner, ".hlx%/"
+    ) OR (@url = "-" AND @repo = "-" AND @owner = "-")
+  GROUP BY id
+),
+current_events_by_url AS (
+  SELECT
+    url,
+    COUNT(id) AS events
+  FROM current_rum_by_id
+  GROUP BY url
+  ORDER BY events DESC
+),
+current_rum_by_url_and_weight AS (
+  SELECT
+    MAX(weight) AS weight,
+    url,
+    CAST(APPROX_QUANTILES(core_web_vital, 100)[OFFSET(75)] AS INT64) AS avg_core_web_vital
+  FROM current_rum_by_id
+  GROUP BY url
+),
+url_above_cwv_count_threshold AS (
+SELECT
+  filtered_data.url,
+  cwv_count,
+  (ce.events * cru.weight) as pageviews,
+  cru.avg_core_web_vital as avg_cwv
+FROM (
+  SELECT
+    cr.url,
+    @cwv_type,
+    count(*) as cwv_count
+    from current_rum_by_id cr
+  WHERE core_web_vital is not null
+  GROUP BY url
+) filtered_data
+LEFT JOIN
+  current_events_by_url ce ON ce.url = filtered_data.url
+LEFT JOIN
+  current_rum_by_url_and_weight cru ON cru.url = filtered_data.url
+WHERE cwv_count > @cwv_count_threshold
+ AND (ce.events * cru.weight) > @interval * @sampling_noise_factor
+)
+SELECT 
+  url,
+  cw_type,
+  cwv_count,
+  pageviews,
+  avg_cwv
+FROM url_above_cwv_count_threshold;

--- a/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
+++ b/src/queries/eds/rum-pageviews-cwv-count-threshold.sql
@@ -7,8 +7,6 @@
 --- timezone: UTC
 --- device: all
 --- url: -
---- owner: -
---- repo: -
 --- cwv_type: lcp
 --- cwv_count_threshold: 100
 --- sampling_noise_factor: 1000
@@ -46,9 +44,6 @@ current_rum_by_id AS (
   FROM current_data
   WHERE
     url LIKE CONCAT("https://", @url, "%")
-    OR url LIKE CONCAT(
-      "https://%", @repo, "--", @owner, ".hlx%/"
-    ) OR (@url = "-" AND @repo = "-" AND @owner = "-")
   GROUP BY id
 ),
 


### PR DESCRIPTION
This introduces a new query for EDS alerting requirements. It aims to return urls, with their respective pageviews and p75 cwv for a given url pattern (e.g.: www.adobe.com/express), having a minimal count of cwv events matching the cwv_type passed as a parameter.

This can be helpful to know which URLs with a cwv count (for the cwv_type passed as parameter, e.g.: LCP) greater than the threshold passed as parameter.

## Related Issues

https://cq-dev.slack.com/archives/C05A45JBP9N/p1700727862022749

Some adjustements from the initial thread have been made

- `cwv_type` added as a parameter to retrieve records with cwv min count (cwv type specific)
- `cwv_count_threshold` minimum count threshold to expose results
- `avg_daily_pageviews_factor` parameter, aiming to reduce pageviews calculation issues related to sampling


Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes