### PR TITLE
feat(pageviews): enable filters for checkpoint, source, and target

### DIFF
--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -63,7 +63,7 @@ monthlydata AS (
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 30, # offset in months
-    @interval * 30, # months to fetch
+    CAST(@interval AS INT64) * 30, # months to fetch
     @startdate, # start date
     @enddate, # end date
     @timezone, # timezone

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -1,137 +1,250 @@
---- description: Get daily page views for a site according to Helix RUM data
+--- description: Get page views for a given URL for a specified time period. You can control the reporting granularity and filter pageviews that have a specific checkpoint, source, and target.
 --- Authorization: none
 --- Access-Control-Allow-Origin: *
 --- interval: 30
 --- offset: 0
+--- startdate: 2020-01-01
+--- enddate: 2020-12-31
+--- checkpoint: -
+--- sources: -
+--- targets: -
 --- url: 
 --- granularity: 1
 --- timezone: UTC
 --- domainkey: secret
-DECLARE results NUMERIC;
-CREATE OR REPLACE PROCEDURE helix_rum.UPDATE_PAGEVIEWS (
-  ingranularity INT64,
-  inlimit INT64,
-  inoffset INT64,
-  inurl STRING,
-  intimezone STRING,
-  indomainkey STRING,
-  OUT results NUMERIC
-)
-BEGIN
-  CREATE TEMP TABLE temp_pageviews (
-    year INT64,
-    month INT64,
-    day INT64,
-    time STRING, --noqa: RF04
-    url INT64,
-    pageviews NUMERIC
+WITH dailydata AS (
+  SELECT
+    id,
+    checkpoint,
+    source,
+    target,
+    pageviews,
+    TIMESTAMP_TRUNC(time, DAY) AS trunc_date
+  FROM helix_rum.EVENTS_V3(
+    @url, # url
+    @offset, # offset
+    @interval, # days to fetch
+    @startdate, # start date
+    @enddate, # end date
+    @timezone, # timezone
+    'all', # deviceclass
+    @domainkey # domain key to prevent data sharing
   )
-  AS
-  WITH current_data AS (
-    SELECT
-      *,
-      CASE ingranularity
-        WHEN 7 THEN TIMESTAMP_TRUNC(time, ISOWEEK)
-        WHEN 30 THEN TIMESTAMP_TRUNC(time, MONTH)
-        WHEN 90 THEN TIMESTAMP_TRUNC(time, QUARTER)
-        WHEN 365 THEN TIMESTAMP_TRUNC(time, YEAR)
-        ELSE TIMESTAMP_TRUNC(time, DAY)
-      END AS date
-    FROM helix_rum.PAGEVIEWS_V3(
-      inurl, # url
-      GREATEST((inoffset * ingranularity) - 1, 0), # offset
-      inlimit * ingranularity, # days to fetch
-      '2022-05-01', # not used, start date
-      '2022-05-28', # not used, end date
-      intimezone, # timezone
-      'all', # deviceclass
-      indomainkey # domain key to prevent data sharing
+),
+
+weeklydata AS (
+  SELECT
+    id,
+    checkpoint,
+    source,
+    target,
+    pageviews,
+    TIMESTAMP_TRUNC(time, ISOWEEK) AS trunc_date
+  FROM helix_rum.EVENTS_V3(
+    @url, # url
+    @offset * 7, # offset in weeks
+    @interval * 7, # weeks to fetch
+    @startdate, # start date
+    @enddate, # end date
+    @timezone, # timezone
+    'all', # deviceclass
+    @domainkey # domain key to prevent data sharing
+  )
+),
+
+monthlydata AS (
+  SELECT
+    id,
+    checkpoint,
+    source,
+    target,
+    pageviews,
+    TIMESTAMP_TRUNC(time, MONTH) AS trunc_date
+  FROM helix_rum.EVENTS_V3(
+    @url, # url
+    @offset * 30, # offset in months
+    @interval * 30, # months to fetch
+    @startdate, # start date
+    @enddate, # end date
+    @timezone, # timezone
+    'all', # deviceclass
+    @domainkey # domain key to prevent data sharing
+  )
+),
+
+quarterlydata AS (
+  SELECT
+    id,
+    checkpoint,
+    source,
+    target,
+    pageviews,
+    TIMESTAMP_TRUNC(time, QUARTER) AS trunc_date
+  FROM helix_rum.EVENTS_V3(
+    @url, # url
+    @offset * 90, # offset in quarters
+    @interval * 90, # quarters to fetch
+    @startdate, # start date
+    @enddate, # end date
+    @timezone, # timezone
+    'all', # deviceclass
+    @domainkey # domain key to prevent data sharing
+  )
+),
+
+yearlydata AS (
+  SELECT
+    id,
+    checkpoint,
+    source,
+    target,
+    pageviews,
+    TIMESTAMP_TRUNC(time, YEAR) AS trunc_date
+  FROM helix_rum.EVENTS_V3(
+    @url, # url
+    @offset * 365, # offset in years
+    @interval * 365, # years to fetch
+    @startdate, # start date
+    @enddate, # end date
+    @timezone, # timezone
+    'all', # deviceclass
+    @domainkey # domain key to prevent data sharing
+  )
+),
+
+all_checkpoints AS (
+  # Combine all the data, so that we have it according to desired granularity
+  SELECT * FROM dailydata WHERE @granularity = 1
+  UNION ALL
+  SELECT * FROM weeklydata WHERE @granularity = 7
+  UNION ALL
+  SELECT * FROM monthlydata WHERE @granularity = 30
+  UNION ALL
+  SELECT * FROM quarterlydata WHERE @granularity = 90
+  UNION ALL
+  SELECT * FROM yearlydata WHERE @granularity = 365
+),
+
+source_target_picked_checkpoints AS (
+  SELECT
+    all_checkpoints.id AS id,
+    ANY_VALUE(source) AS source,
+    ANY_VALUE(target) AS target,
+    ANY_VALUE(all_checkpoints.pageviews) AS pageviews,
+    ANY_VALUE(trunc_date) AS trunc_date
+  FROM all_checkpoints
+  WHERE
+    all_checkpoints.checkpoint = @checkpoint
+    AND EXISTS (
+      SELECT 1
+      FROM
+        UNNEST(SPLIT(@sources, ',')) AS prefix
+      WHERE all_checkpoints.source LIKE CONCAT(TRIM(prefix), '%')
     )
-  ),
+    AND EXISTS (
+      SELECT 1
+      FROM
+        UNNEST(SPLIT(@targets, ',')) AS prefix
+      WHERE all_checkpoints.target LIKE CONCAT(TRIM(prefix), '%')
+    )
+  GROUP BY all_checkpoints.id
+),
 
-  pageviews_by_id AS (
-    SELECT
-      id,
-      MAX(date) AS date,
-      MAX(url) AS url,
-      MAX(pageviews) AS weight
-    FROM current_data
-    GROUP BY id
-  ),
+source_picked_checkpoints AS (
+  SELECT
+    all_checkpoints.id AS id,
+    ANY_VALUE(source) AS source,
+    ANY_VALUE(target) AS target,
+    ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(trunc_date) AS trunc_date
+  FROM all_checkpoints
+  WHERE
+    all_checkpoints.checkpoint = @checkpoint
+    AND EXISTS (
+      SELECT 1
+      FROM
+        UNNEST(SPLIT(@sources, ',')) AS prefix
+      WHERE all_checkpoints.source LIKE CONCAT(TRIM(prefix), '%')
+    )
+  GROUP BY all_checkpoints.id
+),
 
-  dailydata AS (
-    SELECT
-      EXTRACT(YEAR FROM date) AS year,
-      EXTRACT(MONTH FROM date) AS month,
-      EXTRACT(DAY FROM date) AS day,
-      STRING(date) AS time, -- noqa: RF04
-      COUNT(url) AS urls,
-      SUM(weight) AS pageviews
-    FROM pageviews_by_id
-    GROUP BY date
-    ORDER BY date DESC
-  ),
+target_picked_checkpoints AS (
+  SELECT
+    all_checkpoints.id AS id,
+    ANY_VALUE(source) AS source,
+    ANY_VALUE(target) AS target,
+    ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(trunc_date) AS trunc_date
+  FROM all_checkpoints
+  WHERE
+    all_checkpoints.checkpoint = @checkpoint
+    AND EXISTS (
+      SELECT 1
+      FROM
+        UNNEST(SPLIT(@targets, ',')) AS prefix
+      WHERE all_checkpoints.target LIKE CONCAT(TRIM(prefix), '%')
+    )
+  GROUP BY all_checkpoints.id
+),
 
-  basicdates AS (
-    SELECT alldates
-    FROM
-      UNNEST(
-        GENERATE_TIMESTAMP_ARRAY(
-          (SELECT MIN(date) FROM pageviews_by_id),
-          (SELECT MAX(date) FROM pageviews_by_id),
-          INTERVAL 1 DAY
-        )
-      ) AS alldates
-  ),
+loose_picked_checkpoints AS (
+  SELECT
+    all_checkpoints.id AS id,
+    ANY_VALUE(source) AS source,
+    ANY_VALUE(target) AS target,
+    ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(trunc_date) AS trunc_date
+  FROM all_checkpoints
+  WHERE all_checkpoints.checkpoint = @checkpoint
+  GROUP BY all_checkpoints.id
+),
 
-  dates AS (
-    SELECT CASE ingranularity
-      WHEN 7 THEN TIMESTAMP_TRUNC(alldates, ISOWEEK)
-      WHEN 30 THEN TIMESTAMP_TRUNC(alldates, MONTH)
-      WHEN 90 THEN TIMESTAMP_TRUNC(alldates, QUARTER)
-      WHEN 365 THEN TIMESTAMP_TRUNC(alldates, YEAR)
-      ELSE TIMESTAMP_TRUNC(alldates, DAY)
-    END AS alldates FROM basicdates
-    GROUP BY alldates
-  ),
+picked_checkpoints AS (
+  SELECT * FROM loose_picked_checkpoints
+  WHERE @sources = '-' AND @targets = '-' AND @checkpoint != '-'
+  UNION ALL
+  SELECT * FROM source_target_picked_checkpoints
+  WHERE @sources != '-' AND @targets != '-' AND @checkpoint != '-'
+  UNION ALL
+  SELECT * FROM source_picked_checkpoints
+  WHERE @sources != '-' AND @targets = '-' AND @checkpoint != '-'
+  UNION ALL
+  SELECT * FROM target_picked_checkpoints
+  WHERE @sources = '-' AND @targets != '-' AND @checkpoint != '-'
+  UNION ALL
+  SELECT # fallback: just use all data
+    id,
+    source,
+    target,
+    pageviews,
+    trunc_date
+  FROM all_checkpoints WHERE @checkpoint = '-'
+),
 
-  finaldata AS (
-    SELECT
-      EXTRACT(YEAR FROM dates.alldates) AS year,
-      EXTRACT(MONTH FROM dates.alldates) AS month,
-      EXTRACT(DAY FROM dates.alldates) AS day,
-      STRING(dates.alldates) AS time, -- noqa: RF04
-      COALESCE(dailydata.urls, 0) AS distinct_urls,
-      COALESCE(dailydata.pageviews, 0) AS pageviews
-    FROM dates
-    FULL JOIN dailydata
-      ON STRING(dates.alldates) = dailydata.time
-    ORDER BY dates.alldates DESC
-  )
+grouped_checkpoints AS (
+  SELECT
+    id,
+    ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(url) AS url,
+    ANY_VALUE(trunc_date) AS trunc_date
+  FROM picked_checkpoints
+  GROUP BY id
+)
 
-  SELECT * FROM finaldata ORDER BY time DESC;
-  SET results = (SELECT SUM(pageviews) FROM (SELECT * FROM temp_pageviews));
-END;
-IF (CAST(@granularity AS STRING) = "auto") THEN -- noqa: PRS
-    CALL helix_rum.UPDATE_PAGEVIEWS(1, CAST(@interval AS INT64), CAST(@offset AS INT64), @url, @timezone, @domainkey, results);
-    IF (results > (CAST(@interval AS INT64) * 200)) THEN -- noqa: PRS
-        # we have enough results, use the daily granularity
-        SELECT * FROM temp_pageviews;
-    ELSE -- noqa: PRS
-        # we don't have enough results, zoom out
-        DROP TABLE temp_pageviews;
-        CALL helix_rum.UPDATE_PAGEVIEWS(7, CAST(@interval AS INT64), CAST(@offset AS INT64), @url, @timezone, @domainkey, results);
-        IF (results > (CAST(@interval AS INT64) * 200)) THEN
-            # we have enough results, use the weekly granularity
-            SELECT * FROM temp_pageviews;
-        ELSE
-            # we don't have enough results, zoom out to monthly and stop
-            DROP TABLE temp_pageviews;
-            CALL helix_rum.UPDATE_PAGEVIEWS(30, CAST(@interval AS INT64), CAST(@offset AS INT64), @url, @timezone, @domainkey, results);
-            SELECT * FROM temp_pageviews;
-        END IF;
-    END IF; -- noqa: PRS
-ELSE -- noqa: PRS
-    CALL helix_rum.UPDATE_PAGEVIEWS(CAST(@granularity AS INT64), CAST(@interval AS INT64), CAST(@offset AS INT64), @url, @timezone, @domainkey, results);
-    SELECT * FROM temp_pageviews;
-END IF; -- noqa: PRS
+SELECT
+  EXTRACT(YEAR FROM trunc_date) AS year,
+  EXTRACT(MONTH FROM trunc_date) AS month,
+  EXTRACT(DAY FROM trunc_date) AS day,
+  STRING(trunc_date) AS time, -- noqa: RF04
+  COUNT(DISTINCT url) AS url,
+  SUM(pageviews) AS pageviews
+FROM grouped_checkpoints
+GROUP BY trunc_date
+ORDER BY trunc_date DESC
+--- year: the year of the beginning of the reporting interval
+--- month: the month of the beginning of the reporting interval
+--- day: the day of the beginning of the reporting interval
+--- time: the timestamp of the beginning of the reporting interval
+--- url: the number of unique URLs in the reporting interval
+--- pageviews: the number of page views in the reporting interval that match the criteria

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -82,7 +82,7 @@ quarterlydata AS (
     TIMESTAMP_TRUNC(time, QUARTER) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
-    @offset * 90, # offset in quarters
+    CAST(@offset AS INT64) * 90, # offset in quarters
     @interval * 90, # quarters to fetch
     @startdate, # start date
     @enddate, # end date

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -18,7 +18,8 @@ WITH dailydata AS (
     checkpoint,
     source,
     target,
-    pageviews,
+    weight AS pageviews,
+    url,
     TIMESTAMP_TRUNC(time, DAY) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
@@ -38,7 +39,8 @@ weeklydata AS (
     checkpoint,
     source,
     target,
-    pageviews,
+    weight AS pageviews,
+    url,
     TIMESTAMP_TRUNC(time, ISOWEEK) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
@@ -58,7 +60,8 @@ monthlydata AS (
     checkpoint,
     source,
     target,
-    pageviews,
+    weight AS pageviews,
+    url,
     TIMESTAMP_TRUNC(time, MONTH) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
@@ -78,7 +81,8 @@ quarterlydata AS (
     checkpoint,
     source,
     target,
-    pageviews,
+    weight AS pageviews,
+    url,
     TIMESTAMP_TRUNC(time, QUARTER) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
@@ -98,7 +102,8 @@ yearlydata AS (
     checkpoint,
     source,
     target,
-    pageviews,
+    weight AS pageviews,
+    url,
     TIMESTAMP_TRUNC(time, YEAR) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
@@ -131,6 +136,7 @@ source_target_picked_checkpoints AS (
     ANY_VALUE(source) AS source,
     ANY_VALUE(target) AS target,
     ANY_VALUE(all_checkpoints.pageviews) AS pageviews,
+    ANY_VALUE(url) AS url,
     ANY_VALUE(trunc_date) AS trunc_date
   FROM all_checkpoints
   WHERE
@@ -156,6 +162,7 @@ source_picked_checkpoints AS (
     ANY_VALUE(source) AS source,
     ANY_VALUE(target) AS target,
     ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(url) AS url,
     ANY_VALUE(trunc_date) AS trunc_date
   FROM all_checkpoints
   WHERE
@@ -175,6 +182,7 @@ target_picked_checkpoints AS (
     ANY_VALUE(source) AS source,
     ANY_VALUE(target) AS target,
     ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(url) AS url,
     ANY_VALUE(trunc_date) AS trunc_date
   FROM all_checkpoints
   WHERE
@@ -194,6 +202,7 @@ loose_picked_checkpoints AS (
     ANY_VALUE(source) AS source,
     ANY_VALUE(target) AS target,
     ANY_VALUE(pageviews) AS pageviews,
+    ANY_VALUE(url) AS url,
     ANY_VALUE(trunc_date) AS trunc_date
   FROM all_checkpoints
   WHERE all_checkpoints.checkpoint = @checkpoint
@@ -218,6 +227,7 @@ picked_checkpoints AS (
     source,
     target,
     pageviews,
+    url,
     trunc_date
   FROM all_checkpoints WHERE @checkpoint = '-'
 ),

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -62,7 +62,7 @@ monthlydata AS (
     TIMESTAMP_TRUNC(time, MONTH) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
-    @offset * 30, # offset in months
+    CAST(@offset AS INT64) * 30, # offset in months
     @interval * 30, # months to fetch
     @startdate, # start date
     @enddate, # end date

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -102,7 +102,7 @@ yearlydata AS (
     TIMESTAMP_TRUNC(time, YEAR) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
-    @offset * 365, # offset in years
+    CAST(@offset AS INT64) * 365, # offset in years
     @interval * 365, # years to fetch
     @startdate, # start date
     @enddate, # end date

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -103,7 +103,7 @@ yearlydata AS (
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 365, # offset in years
-    @interval * 365, # years to fetch
+    CAST(@interval AS INT64) * 365, # years to fetch
     @startdate, # start date
     @enddate, # end date
     @timezone, # timezone

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -22,7 +22,7 @@ WITH dailydata AS (
     TIMESTAMP_TRUNC(time, DAY) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
-    @offset, # offset
+    CAST(@offset AS INT64), # offset
     @interval, # days to fetch
     @startdate, # start date
     @enddate, # end date

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -43,7 +43,7 @@ weeklydata AS (
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 7, # offset in weeks
-    @interval * 7, # weeks to fetch
+    CAST(@interval AS INT64) * 7, # weeks to fetch
     @startdate, # start date
     @enddate, # end date
     @timezone, # timezone

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -23,7 +23,7 @@ WITH dailydata AS (
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64), # offset
-    @interval, # days to fetch
+    CAST(@interval AS INT64), # days to fetch
     @startdate, # start date
     @enddate, # end date
     @timezone, # timezone

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -42,7 +42,7 @@ weeklydata AS (
     TIMESTAMP_TRUNC(time, ISOWEEK) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
-    @offset * 7, # offset in weeks
+    CAST(@offset AS INT64) * 7, # offset in weeks
     @interval * 7, # weeks to fetch
     @startdate, # start date
     @enddate, # end date

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -119,15 +119,15 @@ yearlydata AS (
 
 all_checkpoints AS (
   # Combine all the data, so that we have it according to desired granularity
-  SELECT * FROM dailydata WHERE @granularity = 1
+  SELECT * FROM dailydata WHERE CAST(@granularity AS INT64) = 1
   UNION ALL
-  SELECT * FROM weeklydata WHERE @granularity = 7
+  SELECT * FROM weeklydata WHERE CAST(@granularity AS INT64) = 7
   UNION ALL
-  SELECT * FROM monthlydata WHERE @granularity = 30
+  SELECT * FROM monthlydata WHERE CAST(@granularity AS INT64) = 30
   UNION ALL
-  SELECT * FROM quarterlydata WHERE @granularity = 90
+  SELECT * FROM quarterlydata WHERE CAST(@granularity AS INT64) = 90
   UNION ALL
-  SELECT * FROM yearlydata WHERE @granularity = 365
+  SELECT * FROM yearlydata WHERE CAST(@granularity AS INT64) = 365
 ),
 
 source_target_picked_checkpoints AS (

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -83,7 +83,7 @@ quarterlydata AS (
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 90, # offset in quarters
-    @interval * 90, # quarters to fetch
+    CAST(@interval AS INT64) * 90, # quarters to fetch
     @startdate, # start date
     @enddate, # end date
     @timezone, # timezone


### PR DESCRIPTION
This is a massive refactoring, and simplification, borrowing the filtering from #1053

It drops the support for `granularity=auto` so we probably have to declare this a breaking change, even if the impact is much smaller than the last breaking change we had.

It also partially reverts the changes made in #1039, negative offsets are now possible again, so that you can use `startdate` and `enddate` parameters