### PR TITLE
fix: add timezone to date functions

### DIFF
--- a/src/queries/rum-checkpoint-urls.sql
+++ b/src/queries/rum-checkpoint-urls.sql
@@ -16,7 +16,7 @@ WITH
 current_data AS (
   SELECT
     *,
-    TIMESTAMP_TRUNC(time, DAY) AS date
+    TIMESTAMP_TRUNC(time, DAY, @timezone) AS date
   FROM
     helix_rum.CHECKPOINTS_V3(
       @url,

--- a/src/queries/rum-content-requests.sql
+++ b/src/queries/rum-content-requests.sql
@@ -13,7 +13,7 @@ FROM (
   SELECT
     hostname,
     ROW_NUMBER() OVER (ORDER BY hostname) AS resrow,
-    FORMAT_TIMESTAMP('%F', TIMESTAMP_TRUNC(time, DAY)) AS day,
+    FORMAT_TIMESTAMP('%F', TIMESTAMP_TRUNC(time, DAY, @timezone)) AS day,
     SUM(pageviews) AS contentrequests
   FROM
     helix_rum.PAGEVIEWS_V3(

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -20,7 +20,7 @@ WITH dailydata AS (
     target,
     weight AS pageviews,
     url,
-    TIMESTAMP_TRUNC(time, DAY) AS trunc_date
+    TIMESTAMP_TRUNC(time, DAY, @timezone) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64), # offset
@@ -41,7 +41,7 @@ weeklydata AS (
     target,
     weight AS pageviews,
     url,
-    TIMESTAMP_TRUNC(time, ISOWEEK) AS trunc_date
+    TIMESTAMP_TRUNC(time, ISOWEEK, @timezone) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 7, # offset in weeks
@@ -62,7 +62,7 @@ monthlydata AS (
     target,
     weight AS pageviews,
     url,
-    TIMESTAMP_TRUNC(time, MONTH) AS trunc_date
+    TIMESTAMP_TRUNC(time, MONTH, @timezone) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 30, # offset in months
@@ -83,7 +83,7 @@ quarterlydata AS (
     target,
     weight AS pageviews,
     url,
-    TIMESTAMP_TRUNC(time, QUARTER) AS trunc_date
+    TIMESTAMP_TRUNC(time, QUARTER, @timezone) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 90, # offset in quarters
@@ -104,7 +104,7 @@ yearlydata AS (
     target,
     weight AS pageviews,
     url,
-    TIMESTAMP_TRUNC(time, YEAR) AS trunc_date
+    TIMESTAMP_TRUNC(time, YEAR, @timezone) AS trunc_date
   FROM helix_rum.EVENTS_V3(
     @url, # url
     CAST(@offset AS INT64) * 365, # offset in years
@@ -245,10 +245,10 @@ grouped_checkpoints AS (
 time_series AS (
   SELECT
     trunc_date,
-    EXTRACT(YEAR FROM trunc_date) AS year,
-    EXTRACT(MONTH FROM trunc_date) AS month,
-    EXTRACT(DAY FROM trunc_date) AS day,
-    STRING(trunc_date) AS time, -- noqa: RF04
+    EXTRACT(YEAR FROM trunc_date AT TIME ZONE @timezone) AS year,
+    EXTRACT(MONTH FROM trunc_date AT TIME ZONE @timezone) AS month,
+    EXTRACT(DAY FROM trunc_date AT TIME ZONE @timezone) AS day,
+    STRING(trunc_date, @timezone) AS time, -- noqa: RF04
     COUNT(DISTINCT url) AS url,
     SUM(pageviews) AS pageviews
   FROM grouped_checkpoints

--- a/src/queries/rum-targets.sql
+++ b/src/queries/rum-targets.sql
@@ -18,7 +18,7 @@ WITH
 current_data AS (
   SELECT
     *,
-    TIMESTAMP_TRUNC(time, DAY) AS date
+    TIMESTAMP_TRUNC(time, DAY, @timezone) AS date
   FROM
     helix_rum.CHECKPOINTS_V3(
       @url,


### PR DESCRIPTION
Some run-queries do not handle timezone consistently.  The most obvious case is for a one-day query which returns two results.

Old: https://helix-pages.anywhere.run/helix-services/run-query@v3/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&interval=-1&offset=-1&startdate=2024-02-20&enddate=2024-02-21&timezone=America/New_York
New: https://helix-pages.anywhere.run/helix-services/run-query@ci6895/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&interval=-1&offset=-1&startdate=2024-02-20&enddate=2024-02-21&timezone=America/New_York

Note: There is a separate issue around EVENTS_V3 in which a one-day query can return two days, if the `time` field is exactly on the midnight hour.  You can see this by replacing `America/New_York` in the URLs above with `America/Chicago`.  This will be resolved with a change to that table function, which may happen separately or together with a proposal to include an entire days worth of data on the end date instead of cutting off at <= midnight.