### PR TITLE
feat: backend to add key to multiple domains in one call

### DIFF
--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -228,7 +228,7 @@ GROUP BY
   source;
 
 CREATE OR REPLACE PROCEDURE
-  helix_rum.ROTATE_DOMAIN_KEYS( IN indomainkey STRING,
+  helix_reporting.ROTATE_DOMAIN_KEYS( IN indomainkey STRING,
     IN inurl STRING,
     IN intimezone STRING,
     IN ingraceperiod INT64,

--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -234,7 +234,8 @@ CREATE OR REPLACE PROCEDURE
     IN ingraceperiod INT64,
     IN inexpirydate STRING,
     IN innewkey STRING,
-    IN inreadonly BOOL)
+    IN inreadonly BOOL,
+    IN innote STRING)
 BEGIN
 -- allow multiple domains to be passed in as comma-separated value
 DECLARE urls ARRAY<STRING>;


### PR DESCRIPTION
As part of the RUM for AEM CS initiative, we are getting requests for 100s of domains to share a single domain key.  It would be a nice convenience to create the domain key for all domains in one request.

This PR is to document and discuss a change to the table function helix_reporting.ROTATE_DOMAIN_KEYS which is a pre-requisite to a run-query change.  Upon approval, I will make the table function change in BigQuery and move on to the run-query changes.

This change is backward compatible -- a single domain may still be passed in.  A test implementation exists at helix_reporting.ROTATE_DOMAIN_KEYS_MULTIPLE for now.
```
CALL helix_reporting.ROTATE_DOMAIN_KEYS_MULTIPLE(
    '<uber_domain_key>',
    '<domain or comma-separated domain list>',
    'UTC',
    -1,
    '-',
    '<desired domain key>',
    true,
    'multiple_test'
);

select * from helix_reporting.domain_keys where note = 'multiple_test';
```
