### PR TITLE
feat: upgrade run-queries to use _V5 table functions

### DIFF
--- a/src/queries/common-event-v5.sql
+++ b/src/queries/common-event-v5.sql
@@ -1,0 +1,108 @@
+CREATE OR REPLACE TABLE
+FUNCTION `helix-225321.helix_rum.EVENTS_V5`(filterurl STRING,
+    days_offset INT64,
+    days_count INT64,
+    day_min STRING,
+    day_max STRING,
+    timezone STRING,
+    deviceclass STRING,
+    domainkey STRING) AS (
+  WITH
+    rawrum AS (
+      SELECT
+        hostname,
+        host,
+        user_agent,
+        time,
+        url,
+        LCP,
+        FID,
+        INP,
+        CLS,
+        TTFB,
+        referer,
+        id,
+        source,
+        target,
+        weight,
+        checkpoint
+      FROM
+        `helix-225321.helix_rum.cluster_cloudflare`
+      UNION ALL
+      SELECT
+        hostname,
+        host,
+        user_agent,
+        time,
+        url,
+        LCP,
+        FID,
+        INP,
+        CLS,
+        TTFB,
+        referer,
+        id,
+        source,
+        target,
+        weight,
+        checkpoint
+      FROM
+        `helix-225321.helix_rum.cluster`
+    ),
+    validkeys AS (
+    SELECT
+      *
+    FROM
+      `helix-225321.helix_reporting.domain_keys`
+    WHERE
+      key_bytes = SHA512(domainkey)
+      AND (revoke_date IS NULL
+        OR revoke_date > CURRENT_DATE(timezone))
+      AND (hostname_prefix = ""
+        OR filterurl LIKE CONCAT("%.", hostname_prefix)
+        OR filterurl LIKE CONCAT("%.", hostname_prefix, "/%")
+        OR filterurl LIKE CONCAT(hostname_prefix)
+        OR filterurl LIKE CONCAT(hostname_prefix, "/%")))
+    SELECT
+      hostname,
+      host,
+      user_agent,
+      time,
+      url,
+      LCP,
+      FID,
+      INP,
+      CLS,
+      TTFB,
+      referer,
+      id,
+      source,
+      target,
+      weight,
+      checkpoint
+   FROM rawrum AS rumdata
+  JOIN
+    validkeys
+  ON
+    ( rumdata.url LIKE CONCAT("https://%.", validkeys.hostname_prefix, "/%")
+      OR rumdata.url LIKE CONCAT("https://", validkeys.hostname_prefix, "/%")
+      OR validkeys.hostname_prefix = "" )
+  WHERE
+    helix_rum.MATCH_URLS_V5(url, filterurl)
+    AND
+  IF
+    (filterurl = '-', TRUE, (hostname = SPLIT(filterurl, '/')[
+      OFFSET
+        (0)])
+      OR (filterurl LIKE 'localhost:%'
+        AND hostname = 'localhost'))
+    AND
+  IF
+    (days_offset >= 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, helix_rum.CLEAN_TIMEZONE(timezone)), INTERVAL days_offset DAY), TIMESTAMP_ADD(TIMESTAMP(day_max, helix_rum.CLEAN_TIMEZONE(timezone)), INTERVAL 1 DAY)) > time
+    AND
+  IF
+    (days_count >= 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, helix_rum.CLEAN_TIMEZONE(timezone)), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, helix_rum.CLEAN_TIMEZONE(timezone))) <= time
+    AND helix_rum.CLUSTER_FILTERCLASS(user_agent,
+      deviceclass)
+
+);

--- a/src/queries/common-event-v5.sql
+++ b/src/queries/common-event-v5.sql
@@ -1,5 +1,6 @@
 CREATE OR REPLACE TABLE
-FUNCTION `helix-225321.helix_rum.EVENTS_V5`(filterurl STRING,
+FUNCTION `helix-225321.helix_rum.EVENTS_V5`( -- noqa: PRS
+    filterurl STRING,
     days_offset INT64,
     days_count INT64,
     day_min STRING,

--- a/src/queries/dash/domain-list.sql
+++ b/src/queries/dash/domain-list.sql
@@ -18,7 +18,7 @@ WITH pvs AS (
     MIN(time) AS first_visit,
     MAX(time) AS last_visit
   FROM
-    helix_rum.PAGEVIEWS_V3(
+    helix_rum.PAGEVIEWS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/ee-score.sql
+++ b/src/queries/ee-score.sql
@@ -78,7 +78,7 @@ WITH visits AS (
     MAX(IF(checkpoint = "load", 1, 0)) AS load,
     MAX(IF(checkpoint = "click", 1, 0)) AS click
   FROM
-    helix_rum.EVENTS_V3(
+    helix_rum.EVENTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-bounces.sql
+++ b/src/queries/rum-bounces.sql
@@ -16,7 +16,7 @@ WITH current_data AS (
     time AS time_stamp,
     pageviews
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-checkpoint-cwv-correlation.sql
+++ b/src/queries/rum-checkpoint-cwv-correlation.sql
@@ -21,7 +21,7 @@ WITH alldata AS (
     target,
     lcp
   FROM
-    `helix-225321.helix_rum.EVENTS_V3`(
+    `helix-225321.helix_rum.EVENTS_V5`(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),
@@ -35,7 +35,7 @@ WITH alldata AS (
 
 all_checkpoints AS (
   SELECT * FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url, # domain or URL
       CAST(@offset AS INT64), # offset in days from today
       CAST(@interval AS INT64), # interval in days to consider

--- a/src/queries/rum-checkpoint-urls.sql
+++ b/src/queries/rum-checkpoint-urls.sql
@@ -18,7 +18,7 @@ current_data AS (
     *,
     TIMESTAMP_TRUNC(time, DAY, @timezone) AS date
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-checkpoints.sql
+++ b/src/queries/rum-checkpoints.sql
@@ -17,7 +17,7 @@ weightdata AS (
     MAX(pageviews) AS weight,
     ANY_VALUE(url) AS url,
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64), # offset in days
       CAST(@interval AS INT64), # interval in days to consider

--- a/src/queries/rum-checkpoints.sql
+++ b/src/queries/rum-checkpoints.sql
@@ -15,7 +15,7 @@ weightdata AS (
     checkpoint,
     id,
     MAX(pageviews) AS weight,
-    ANY_VALUE(url) AS url,
+    ANY_VALUE(url) AS url
   FROM
     helix_rum.CHECKPOINTS_V5(
       @url,

--- a/src/queries/rum-content-requests.sql
+++ b/src/queries/rum-content-requests.sql
@@ -16,7 +16,7 @@ FROM (
     FORMAT_TIMESTAMP('%F', TIMESTAMP_TRUNC(time, DAY, @timezone)) AS day,
     SUM(pageviews) AS contentrequests
   FROM
-    helix_rum.PAGEVIEWS_V3(
+    helix_rum.PAGEVIEWS_V5(
       '-', # url
       CAST(@offset AS INT64), # offset
       -1, # days to fetch

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -31,7 +31,7 @@ AS (
 WITH
 current_data AS (
   SELECT * FROM
-    helix_rum.EVENTS_V3(
+    helix_rum.EVENTS_V5(
       @url, # domain or URL
       CAST(@offset AS INT64), # not used, offset in days from today
       CAST(@interval AS INT64), # interval in days to consider
@@ -45,7 +45,7 @@ current_data AS (
 
 previous_data AS (
   SELECT * FROM
-    helix_rum.EVENTS_V3(
+    helix_rum.EVENTS_V5(
       @url, # domain or URL
       # offset in days from today
       CAST(@interval AS INT64) + CAST(@offset AS INT64),

--- a/src/queries/rum-experiments.sql
+++ b/src/queries/rum-experiments.sql
@@ -41,7 +41,7 @@ LANGUAGE js AS """
 WITH
 all_checkpoints AS (
   SELECT * FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url, # domain or URL
       CAST(@offset AS INT64), # offset in days from today
       CAST(@interval AS INT64), # interval in days to consider

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -85,7 +85,7 @@ alldata AS (
     lcp,
     time
   FROM
-    `helix-225321.helix_rum.EVENTS_V3`(
+    `helix-225321.helix_rum.EVENTS_V5`(
       @url,
       -1, # not used
       -1, # not used

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -128,7 +128,7 @@ allids AS (
     ANY_VALUE(named_intervals.interval_end) AS interval_end
   FROM alldata INNER JOIN named_intervals
     ON (
-      named_intervals.interval_start <= alldata.time
+      alldata.time >= named_intervals.interval_start
       AND alldata.time < named_intervals.interval_end
     )
   GROUP BY alldata.id

--- a/src/queries/rum-intervals.sql
+++ b/src/queries/rum-intervals.sql
@@ -144,7 +144,7 @@ events AS (
     COUNT(DISTINCT linkclickevents.target) AS linkclicks
   FROM linkclickevents
   FULL JOIN allids ON linkclickevents.id = allids.id
-  FULL JOIN alllcps ON alllcps.id = allids.id
+  FULL JOIN alllcps ON allids.id = alllcps.id
   GROUP BY allids.id
 ),
 

--- a/src/queries/rum-pageviews-pivot.sql
+++ b/src/queries/rum-pageviews-pivot.sql
@@ -57,7 +57,7 @@ WITH pvs AS (
     REGEXP_REPLACE(hostname, r'^www.', '') AS hostname,
     FORMAT_DATE('%Y-%b', time) AS month
   FROM
-    helix_rum.PAGEVIEWS_V3(
+    helix_rum.PAGEVIEWS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -21,7 +21,7 @@ WITH dailydata AS (
     weight AS pageviews,
     url,
     TIMESTAMP_TRUNC(time, DAY, @timezone) AS trunc_date
-  FROM helix_rum.EVENTS_V3(
+  FROM helix_rum.EVENTS_V5(
     @url, # url
     CAST(@offset AS INT64), # offset
     CAST(@interval AS INT64), # days to fetch
@@ -42,7 +42,7 @@ weeklydata AS (
     weight AS pageviews,
     url,
     TIMESTAMP_TRUNC(time, ISOWEEK, @timezone) AS trunc_date
-  FROM helix_rum.EVENTS_V3(
+  FROM helix_rum.EVENTS_V5(
     @url, # url
     CAST(@offset AS INT64) * 7, # offset in weeks
     CAST(@interval AS INT64) * 7, # weeks to fetch
@@ -63,7 +63,7 @@ monthlydata AS (
     weight AS pageviews,
     url,
     TIMESTAMP_TRUNC(time, MONTH, @timezone) AS trunc_date
-  FROM helix_rum.EVENTS_V3(
+  FROM helix_rum.EVENTS_V5(
     @url, # url
     CAST(@offset AS INT64) * 30, # offset in months
     CAST(@interval AS INT64) * 30, # months to fetch
@@ -84,7 +84,7 @@ quarterlydata AS (
     weight AS pageviews,
     url,
     TIMESTAMP_TRUNC(time, QUARTER, @timezone) AS trunc_date
-  FROM helix_rum.EVENTS_V3(
+  FROM helix_rum.EVENTS_V5(
     @url, # url
     CAST(@offset AS INT64) * 90, # offset in quarters
     CAST(@interval AS INT64) * 90, # quarters to fetch
@@ -105,7 +105,7 @@ yearlydata AS (
     weight AS pageviews,
     url,
     TIMESTAMP_TRUNC(time, YEAR, @timezone) AS trunc_date
-  FROM helix_rum.EVENTS_V3(
+  FROM helix_rum.EVENTS_V5(
     @url, # url
     CAST(@offset AS INT64) * 365, # offset in years
     CAST(@interval AS INT64) * 365, # years to fetch

--- a/src/queries/rum-sources-targets.sql
+++ b/src/queries/rum-sources-targets.sql
@@ -16,7 +16,7 @@ WITH
 current_data AS (
   SELECT *
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-sources-targets.sql
+++ b/src/queries/rum-sources-targets.sql
@@ -42,7 +42,11 @@ sources AS (
   WHERE
     source IS NOT NULL
     AND (@source = '-' OR source = @source)
-    AND (CAST(@checkpoint AS STRING) = '-' OR CAST(@checkpoint AS STRING) = checkpoint)
+    AND (
+      CAST(@checkpoint AS STRING) = '-'
+      OR
+      CAST(@checkpoint AS STRING) = checkpoint
+    )
   GROUP BY source, id, checkpoint, target
 )
 

--- a/src/queries/rum-sources.sql
+++ b/src/queries/rum-sources.sql
@@ -16,7 +16,7 @@ WITH
 current_data AS (
   SELECT *
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),

--- a/src/queries/rum-targets.sql
+++ b/src/queries/rum-targets.sql
@@ -20,7 +20,7 @@ current_data AS (
     *,
     TIMESTAMP_TRUNC(time, DAY, @timezone) AS date
   FROM
-    helix_rum.CHECKPOINTS_V3(
+    helix_rum.CHECKPOINTS_V5(
       @url,
       CAST(@offset AS INT64),
       CAST(@interval AS INT64),


### PR DESCRIPTION
Two benefits from this PR:
1) Combine cloudflare- and fastly-sourced RUM data
2) Change so that `enddate` includes information from that date for date-based queries

`ci6936` has these changes.  I will test all before merging.  Given so many queries were touched, to avoid merge conflicts I ask you to not work on other run-query changes until after this is merged.  Please review and comment now, but I will handle the merge.
