### PR TITLE
Pageviews hourly granularity

### DIFF
--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -409,7 +409,7 @@ placeholders AS (
     EXTRACT(MONTH FROM slot) AS month,
     EXTRACT(DAY FROM slot) AS day,
     0 AS hour, -- noqa: RF04
-    STRING(TIMESTAMP(slot, @timezone)) AS time -- noqa: RF04
+    STRING(TIMESTAMP(slot, @timezone), @timezone) AS time -- noqa: RF04
   FROM weeklyslots
   UNION ALL
   SELECT
@@ -422,7 +422,7 @@ placeholders AS (
     EXTRACT(MONTH FROM slot) AS month,
     EXTRACT(DAY FROM slot) AS day,
     0 AS hour, -- noqa: RF04
-    STRING(TIMESTAMP(slot, @timezone)) AS time -- noqa: RF04
+    STRING(TIMESTAMP(slot, @timezone), @timezone) AS time -- noqa: RF04
   FROM monthlyslots
   UNION ALL
   SELECT
@@ -435,7 +435,7 @@ placeholders AS (
     EXTRACT(MONTH FROM slot) AS month,
     EXTRACT(DAY FROM slot) AS day,
     0 AS hour, -- noqa: RF04
-    STRING(TIMESTAMP(slot, @timezone)) AS time -- noqa: RF04
+    STRING(TIMESTAMP(slot, @timezone), @timezone) AS time -- noqa: RF04
   FROM quarterlyslots
   UNION ALL
   SELECT
@@ -448,7 +448,7 @@ placeholders AS (
     EXTRACT(MONTH FROM slot) AS month,
     EXTRACT(DAY FROM slot) AS day,
     0 AS hour, -- noqa: RF04
-    STRING(TIMESTAMP(slot, @timezone)) AS time -- noqa: RF04
+    STRING(TIMESTAMP(slot, @timezone), @timezone) AS time -- noqa: RF04
   FROM yearlyslots
 ),
 


### PR DESCRIPTION
As part of the initiative to make RUM data more timely, this PR adds an option to see page views by hour using a new granularity value of 24.

Notes:
- For the hourly granularity, we fill in traffic-less hours with 0 values.  This was preferred to providing only a subset of hours in a day.
- It's possible the "rule of three" forecast logic is not correct for the hourly granularity, @trieloff to review.  The dashboard does not use the forecast fields at this time so I consider this a minor issue.
- For consumers of this API, I think we will want to think about limiting the resultset size.  For example, the default 30 days used by the dashboard will turn into 30*24=720 hourly data points which may overwhelm.

Sample call: https://helix-pages.anywhere.run/helix-services/run-query@ci6968/rum-pageviews?domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&url=www.aem.live&granularity=24&offset=-1&interval=-1&startdate=2024-03-06&enddate=2024-03-06&timezone=America/Chicago