### PR TITLE
fix: exclude future events

### DIFF
--- a/src/queries/common-event-v5.sql
+++ b/src/queries/common-event-v5.sql
@@ -105,5 +105,5 @@ FUNCTION `helix-225321.helix_rum.EVENTS_V5`( -- noqa: PRS
     (days_count >= 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, helix_rum.CLEAN_TIMEZONE(timezone)), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, helix_rum.CLEAN_TIMEZONE(timezone))) <= time
     AND helix_rum.CLUSTER_FILTERCLASS(user_agent,
       deviceclass)
-
+    AND time < CURRENT_TIMESTAMP()
 );


### PR DESCRIPTION
RUM collection adds padding to the current time for PII purposes.  See https://github.com/adobe/helix-rum-collector/blob/main/src/utils.mjs#L29

With the addition of hourly-based reporting for the current day, this can lead to the appearance of future events which will raise questions among users.  Decision was made to exclude future events from reporting.
