### PR TITLE
Stable Bundles

### DIFF
--- a/src/queries/rum-bundles.sql
+++ b/src/queries/rum-bundles.sql
@@ -47,3 +47,5 @@ GROUP BY
   id,
   url,
   TIMESTAMP_TRUNC(time, DAY)
+ORDER BY
+  time DESC

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -79,7 +79,7 @@ export async function execute(email, key, project, query, _, params = {}) {
     return new Promise(async (resolve, reject) => {
       const results = [];
       let avgsize = 0;
-      const maxsize = 1024 * 1024 * 0.9;
+      const maxsize = 1024 * 1024 * 6 * 0.9;
       // eslint-disable-next-line no-param-reassign
       requestParams.limit = parseInt(requestParams.limit, 10);
       const headers = cleanHeaderParams(loadedQuery, headerParams, true);


### PR DESCRIPTION
This will make sure that `rum-bundles` response does not vary with repeated executions

- fix(bundles): sort bundles by date
- fix(sendquery): bump response size limit to 6MB
