### PR TITLE
fix: daylight savings placeholder

### DIFF
--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -295,9 +295,16 @@ hourlyslots AS (
 dailyslots AS (
   SELECT *
   FROM UNNEST(
-    GENERATE_TIMESTAMP_ARRAY(
-      TIMESTAMP(@startdate, @timezone),
-      TIMESTAMP_ADD(TIMESTAMP(@enddate, @timezone), INTERVAL 23 HOUR),
+    GENERATE_DATE_ARRAY(
+      -- do not add timezone here because the placeholder 0s may shift a day too early
+      DATE(TIMESTAMP_TRUNC(@startdate, DAY)),
+      DATE(
+        TIMESTAMP_TRUNC(
+          TIMESTAMP_ADD(TIMESTAMP(@enddate, @timezone), INTERVAL 23 HOUR),
+          DAY,
+          @timezone
+        )
+      ),
       INTERVAL 1 DAY
     )
   ) AS slot
@@ -392,11 +399,11 @@ placeholders AS (
     0 AS pageviews_forecast,
     0 AS url_forecast,
     1 AS granularity,
-    EXTRACT(YEAR FROM slot AT TIME ZONE @timezone) AS year,
-    EXTRACT(MONTH FROM slot AT TIME ZONE @timezone) AS month,
-    EXTRACT(DAY FROM slot AT TIME ZONE @timezone) AS day,
-    EXTRACT(HOUR FROM slot AT TIME ZONE @timezone) AS hour, -- noqa: RF04
-    STRING(slot, @timezone) AS time -- noqa: RF04
+    EXTRACT(YEAR FROM slot) AS year,
+    EXTRACT(MONTH FROM slot) AS month,
+    EXTRACT(DAY FROM slot) AS day,
+    0 AS hour, -- noqa: RF04
+    STRING(TIMESTAMP(slot, @timezone), @timezone) AS time -- noqa: RF04
   FROM dailyslots
   UNION ALL
   SELECT


### PR DESCRIPTION
Cedric and Ekrem noticed that the page views chart in the datadesk dashboard looked choppy.  Further investigation showed this was due to the presence of duplicate dates which were offset by one hour when the date range overlapped with a daylight savings change -- one of the duplicate dates always showed 0 page views.  You can see this at https://helix-pages.anywhere.run/helix-services/run-query@v3/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&startdate=2024-03-07&enddate=2024-03-14&timezone=America%2FLos_Angeles&interval=-1&offset=-1 with different data behavior around the daylight savings shift the weekend of March 11.

This issue is due to a combination of factors:
1) The addition of timezone functionality in the dashboard.  The default "timezone" UTC is not affected by daylight savings.
2) The decision to add placeholder values of 0 for any interval without data.  This was added at the same time the hourly granularity was introduced so that intervals with no traffic are shown alongside intervals with traffic -- in other words, an attempt to address an issue we sometimes see with zooming in too close.
3) The implementation of the placeholder 0s spans from start date to end date, adding `INTERVAL 1 DAY` (read: 24 hours) then performs a UNION ALL with what is expected to be the same dates that have data.  The result for a low traffic site was expected to be something like 800, 300, 0, 400, 200, 0, 100.  However, the INTERVAL 1 DAY technique does not work when one of the intervals should be 23 hours or 25 hours to accommodate the daylight savings change -- it leads to non-overlapping periods which explains the issue seen here.

The first attempt at a solution in this PR handles days as DATE instead of TIMESTAMP.  It resolves the placeholder 0s issue (use `ci7191`) as can be seen at https://helix-pages.anywhere.run/helix-services/run-query@ci7191/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&startdate=2024-03-07&enddate=2024-03-14&timezone=America%2FLos_Angeles&interval=-1&offset=-1 but the daily data is slightly different.  That is because of the more crude handling of timezones in this approach.  This isn't terribly relevant when one zooms out because the differences get washed away, but when zooming in it can lead to questions.

At this point I think we have to make a choice -- keep the placeholder 0s and lose a little control of the timezone aggregation, or lose some of the placeholder 0s (those after a timezone change) and keep control of the timezone aggregation.  The first commit in this PR keeps the placeholder 0s and loses some timezone control.  It's also possible we can do both, but I haven't found that solution yet.