### PR TITLE
fix: placeholder days after daylight savings

### DIFF
--- a/src/queries/rum-pageviews.sql
+++ b/src/queries/rum-pageviews.sql
@@ -298,7 +298,7 @@ dailyslots AS (
     GENERATE_TIMESTAMP_ARRAY(
       TIMESTAMP(@startdate, @timezone),
       TIMESTAMP_ADD(TIMESTAMP(@enddate, @timezone), INTERVAL 23 HOUR),
-      INTERVAL 1 DAY
+      INTERVAL 1 HOUR
     )
   ) AS slot
 ),


### PR DESCRIPTION
Small addition to #1085 to allow placeholder 0s after the daylight savings switch, as this was the original intent.

v3: https://helix-pages.anywhere.run/helix-services/run-query@v3/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&startdate=2024-03-01&enddate=2024-03-31&timezone=America%2FLos_Angeles&interval=-1&offset=-1

ci7212: https://helix-pages.anywhere.run/helix-services/run-query@ci7212/rum-pageviews?url=www.aem.live&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659&startdate=2024-03-01&enddate=2024-03-31&timezone=America%2FLos_Angeles&interval=-1&offset=-1

Note the final days of March (future) do not exist in the first and are populated with 0s in the second.
