### PR TITLE
feat: new 404 query grouped by url with source count

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
       "src/queries/guess-hostname.sql",
       "src/queries/revoke-domainkey.sql",
       "src/queries/rotate-domainkeys.sql",
+      "src/queries/rum-404.sql",
       "src/queries/rum-bounces.sql",
       "src/queries/rum-bundles.sql",
       "src/queries/rum-checkpoint-cwv-correlation.sql",

--- a/src/queries/rum-404.sql
+++ b/src/queries/rum-404.sql
@@ -40,7 +40,7 @@ checkpoint_urls AS (
 
 SELECT
   url,
-  APPROX_TOP_COUNT(source, 1)[OFFSET(0)].value AS top_source,
+  APPROX_TOP_SUM(source, views, 1)[OFFSET(0)].value AS top_source,
   COUNT(source) AS source_count,
   SUM(views) AS views
 FROM checkpoint_urls

--- a/src/queries/rum-404.sql
+++ b/src/queries/rum-404.sql
@@ -1,0 +1,49 @@
+--- description: Get popularity data for RUM target attribute values, filtered by checkpoint
+--- Authorization: none
+--- Access-Control-Allow-Origin: *
+--- limit: 30
+--- interval: 30
+--- offset: 0
+--- startdate: 2022-01-01
+--- enddate: 2022-01-31
+--- timezone: UTC
+--- url: -
+--- domainkey: secret
+
+WITH
+current_data AS (
+  SELECT
+    *,
+    TIMESTAMP_TRUNC(time, DAY, @timezone) AS date
+  FROM
+    helix_rum.CHECKPOINTS_V5(
+      @url,
+      CAST(@offset AS INT64),
+      CAST(@interval AS INT64),
+      @startdate,
+      @enddate,
+      @timezone,
+      'all',
+      @domainkey
+    )
+  WHERE checkpoint = '404'
+),
+
+checkpoint_urls AS (
+  SELECT
+    url,
+    source,
+    COUNT(DISTINCT id) * MAX(pageviews) AS views
+  FROM current_data
+  GROUP BY url, checkpoint, source
+)
+
+SELECT
+  url,
+  APPROX_TOP_COUNT(source, 1)[OFFSET(0)].value AS top_source,
+  COUNT(source) AS source_count,
+  SUM(views) AS views
+FROM checkpoint_urls
+GROUP BY url
+ORDER BY views DESC -- noqa: PRS
+LIMIT CAST(@limit AS INT64)


### PR DESCRIPTION
New query for 404s.  The one currently used by the dashboard groups by source, shows the top url for the source, and that has led to questions around data mismatches.  See https://github.com/adobe/franklin-dashboard/issues/66.

Test at https://helix-pages.anywhere.run/helix-services/run-query@ci7231/rum-404 with a url and domain key which is known to have 404 data.