### PR TITLE
feat: allow comma-separated list of domains as input param

### DIFF
--- a/src/queries/common-event-v5.sql
+++ b/src/queries/common-event-v5.sql
@@ -66,7 +66,7 @@ FUNCTION `helix-225321.helix_rum.EVENTS_V5`( -- noqa: PRS
         OR filterurl LIKE CONCAT(hostname_prefix)
         OR filterurl LIKE CONCAT(hostname_prefix, "/%")
         -- handle comma-separated list of urls, remove spaces and trailing comma
-        OR hostname_prefix IN (SELECT * FROM UNNEST(SPLIT(REGEXP_REPLACE(RTRIM(filterurl, ','), ' ', ''), ',')))
+        OR hostname_prefix IN (SELECT * FROM helix_rum.URLS_FROM_LIST(filterurl))
       )
     )
     SELECT
@@ -108,7 +108,7 @@ FUNCTION `helix-225321.helix_rum.EVENTS_V5`( -- noqa: PRS
         )
       )
       -- handle comma-separated list of urls, remove spaces and trailing comma
-      OR hostname IN (SELECT * FROM UNNEST(SPLIT(REGEXP_REPLACE(RTRIM(filterurl, ','), ' ', ''), ',')))
+      OR hostname IN (SELECT * FROM helix_rum.URLS_FROM_LIST(filterurl))
     )
     AND
   IF

--- a/src/queries/rum-common.sql
+++ b/src/queries/rum-common.sql
@@ -366,6 +366,9 @@ BEGIN
   );
 END;
 
+CREATE OR REPLACE TABLE FUNCTION helix_rum.URLS_FROM_LIST(inurls STRING) AS (
+  SELECT * FROM UNNEST(SPLIT(REGEXP_REPLACE(RTRIM(inurls, ','), ' ', ''), ',')) AS url
+);
 
 # SELECT * FROM helix_rum.CLUSTER_PAGEVIEWS('blog.adobe.com', 1, 7, '', '', 'GMT', 'desktop', '-')
 # ORDER BY time DESC


### PR DESCRIPTION
This proposed change is to the foundational EVENTS_V5 table function.  Upon merging, I will make the change directly in BigQuery.

Currently the url param assumes one domain or url.  You can see the logic around matching the param with the domain key hostname prefix (alongside various prefix and suffix CONCAT logic) as well as splitting the param into multiple parts to match against the event hostname field.

The proposed change is based on a requirement for the new content requests run-query to accept a comma-separated list of domains and return data for each (cc: @lydiapuric).  There were a few indentation adjustments but two core changes:
- The first is to match each domain in the comma-separated list against the domain key, and events are only returned if the given domain key is valid for all domains in the list.
- The second is to bypass the logic requiring a match in the event `url` field if the event `hostname` matches any of the domains in the comma-separated list.  The implication here is that we will not support comma-separate domains with paths.  We will support (1) a single domain as we do today, (2) a single domain with a path as we do today, or (3) a list of domains which is a new feature but not (4) a list of domains with paths.

EVENTS_V5 is used by nearly every run-query.  Not all run-queries will react intuitively to this change if a user passes in a comma-separated list.  My initial analysis is that queries that include a url in the result will handle the urls from multiple domains as siblings without any sort of domain-based nesting (Category 1):
- rum-404
- rum-bundles
- rum-checkpoint-urls
- rum-content-requests (and rum-contentrequests)
- rum-dashboard
- rum-experiments
- rum-forms-dashboard
- rum-pageviews-pivot
- rum-sources-targets
- rum-sources
- rum-targets

And run-queries which do not include a url in the result will just aggregate from multiple domains without any ability to separate one domain from another (Category 2):
- rum-bounces
- rum-checkpoint-cwv-correlation
- rum-checkpoints
- rum-intervals
- rum-pageviews

It may make sense to adjust some of the Category 2 run-queries such as rum-pageviews to allow segmentation by domain but this could be considered a breaking change and should be done thoughtfully.

No analysis has been done yet on the datadesk dashboard for the impact of this change.  It's quite possible that we want to disallow any url field with a comma to be entered into the dashboard until such time we have tested and thought through all the implications (cc: @MarquiseRosier).

Because the change to this table function has the potential to be impactful, I suggest we do not actively promote this new multi-domain capability until we have a more complete understanding of the impact (and dos and don'ts) after thoroughly testing ourselves.  Lars is on PTO but has given his blessing to proceed, so he is not listed as an approver on the PR at this time.

Finally, for context, there is a separate but potentially related notion of domain groups, which would allow us to group multiple domains together.  Think of it like an implicit version of handling multiple domains, while this PR is about explicitly listing the domains.  The use cases for domain groups are not fully fleshed out yet.  It's possible this approach may make domain groups moot, and also possible domain groups may make this explicit approach obsolete in the future, and also possible the two approaches will someday live in harmony.  We will see what works and what doesn't as we gain experience.