### PR TITLE
Go-live hints for spacecat

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
       "src/queries/rum-sources.sql",
       "src/queries/rum-targets.sql",
       "src/queries/dash/auth-all-domains.sql",
+      "src/queries/dash/edge-delivery-live-hints.sql",
       "src/queries/dash/domain-list.sql",
       "src/queries/dash/update-domain-info.sql",
       "src/queries/dash/add-lhs-data.sql"

--- a/src/queries/dash/edge-delivery-live-hints.sql
+++ b/src/queries/dash/edge-delivery-live-hints.sql
@@ -1,0 +1,43 @@
+--- description: Get Edge Delivery domains with the first RUM collection in past 30 days yesterday
+--- Authorization: none
+--- Access-Control-Allow-Origin: *
+--- limit: 200
+--- interval: 30
+--- offset: 0
+--- startdate: 2022-01-01
+--- enddate: 2022-01-31
+--- timezone: UTC
+--- url: -
+--- domainkey: secret
+
+WITH hosts AS (
+  SELECT
+    hostname,
+    DATE(MIN(TIMESTAMP_TRUNC(time, DAY, @timezone))) AS first_rum
+  FROM
+    helix_rum.EVENTS_V5(
+      @url,
+      CAST(@offset AS INT64),
+      CAST(@interval AS INT64),
+      @startdate,
+      @enddate,
+      @timezone,
+      'all',
+      @domainkey
+    )
+  WHERE
+    checkpoint = 'top'
+    AND NOT (
+      host LIKE '%adobeaemcloud.net'
+      AND hostname NOT LIKE '%adobeaemcloud.com'
+      AND host != hostname
+    )
+  GROUP BY hostname
+)
+
+SELECT
+  hostname,
+  first_rum
+FROM hosts
+WHERE first_rum >= CURRENT_DATE(@timezone) - 1
+LIMIT @limit

--- a/src/queries/dash/edge-delivery-live-hints.sql
+++ b/src/queries/dash/edge-delivery-live-hints.sql
@@ -29,9 +29,14 @@ WITH hosts AS (
     checkpoint = 'top'
     AND NOT (
       host LIKE '%adobeaemcloud.net'
-      AND hostname NOT LIKE '%adobeaemcloud.com'
       AND host != hostname
     )
+    AND hostname NOT LIKE '%.hlx.live'
+    AND hostname NOT LIKE '%.hlx.page'
+    AND hostname NOT LIKE '%.aem.live'
+    AND hostname NOT LIKE '%.aem.page'
+    AND hostname NOT LIKE '%.pfizer'
+    AND hostname NOT LIKE '%.adobeaemcloud.com'
   GROUP BY hostname
 )
 


### PR DESCRIPTION
This query shows domains (with certain exclusions per the SQL) which had their first RUM collection in at least 30 days.  This is used as a hint that the domain might have gone live yesterday.  Spacecat will call it once per day and use it to augment data from other sources.

`https://helix-pages.anywhere.run/helix-services/run-query@ci7450/dash/edge-delivery-live-hints?domainkey=<global_domain_key>`
