### PR TITLE
Add TTFB to rum-dashboard

### DIFF
--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -36,7 +36,7 @@ createTargets().forEach((target) => {
           expect(response).to.have.status(200);
           expect(response).to.have.header('Content-Type', /^application\/json/);
           // validate the response body
-          expect(response.body.meta.data).to.have.lengthOf(43);
+          expect(response.body.meta.data).to.have.lengthOf(49);
         })
         .catch((e) => {
           throw e;

--- a/test/testQueries.js
+++ b/test/testQueries.js
@@ -67,7 +67,7 @@ describe('Test Queries', () => {
     }
     assert.ok(json.results.data);
     assert.ok(json.meta.data.filter((e) => e.name === 'domainkey').length === 0, 'domainkey should not be in requestParams');
-    assert.equal(json.meta.data.length, 44);
+    assert.equal(json.meta.data.length, 50);
   }).timeout(100000);
 
   it('rum-bundles', async () => {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -43,7 +43,7 @@ describe('testing util functions', () => {
 
   it('loadQuery works with trailing parameters', async () => {
     const result = await loadQuery('rum-dashboard');
-    assert.equal(Object.keys(getTrailingParams(result)).length, 31);
+    assert.equal(Object.keys(getTrailingParams(result)).length, 37);
   });
 
   it('loadQuery throws with bad query file', async () => {


### PR DESCRIPTION
Add TTFB to rum-dashboard query.  The data already exists, just not currently available in API.

Before: http://helix-pages.anywhere.run/helix-services/run-query@v3/rum-dashboard?url=www.aem.live/home&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659
After: http://helix-pages.anywhere.run/helix-services/run-query@ci7508/rum-dashboard?url=www.aem.live/home&domainkey=d77c830d-3ec9-4611-8b86-256346fa7659

## Related Issues
#1116 
