### PR TITLE
pre-validate domain key for queries

### DIFF
--- a/src/queries/multi-results.sql
+++ b/src/queries/multi-results.sql
@@ -26,4 +26,4 @@ SELECT
   events,
   metadata,
   meta_array
-FROM all_results LIMIT 1;
+FROM all_results LIMIT 1

--- a/src/queries/multi-results.sql
+++ b/src/queries/multi-results.sql
@@ -26,4 +26,4 @@ SELECT
   events,
   metadata,
   meta_array
-FROM all_results LIMIT 1
+FROM all_results LIMIT 1;

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -576,7 +576,7 @@ FROM (
 ) WHERE
   rank <= @limit OR url = "Other" OR @rising;
 
-END IF
+END IF;
 --- avgcls: 75th percentile value of the Cumulative Layout Shift metric in the current period
 --- avgcls_1: 75th percentile value of the CLS metric in the previous period
 --- avgfid: 75th percentile value of the First Input Delay metric in milliseconds in the current period

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -27,28 +27,6 @@ AS (
   OR (device = "bot" AND user_agent NOT LIKE "Mozilla%")
 );
 
-IF EXISTS(
-    SELECT
-      *
-    FROM
-      `helix-225321.helix_reporting.domain_keys`
-    WHERE
-      key_bytes = SHA512(@domainkey)
-      AND (revoke_date IS NULL
-        OR revoke_date > CURRENT_DATE(@timezone))
-      AND (
-        hostname_prefix = ""
-        OR @url LIKE CONCAT("%.", hostname_prefix)
-        OR @url LIKE CONCAT("%.", hostname_prefix, "/%")
-        OR @url LIKE CONCAT(hostname_prefix)
-        OR @url LIKE CONCAT(hostname_prefix, "/%")
-        -- handle comma-separated list of urls, remove spaces and trailing comma
-        OR hostname_prefix IN (SELECT * FROM helix_rum.URLS_FROM_LIST(@url))
-      )
-    )
-
-THEN
-
 WITH
 current_data AS (
   SELECT * FROM
@@ -574,9 +552,8 @@ FROM (
     current_truncated_rum_by_url.pageviews DESC,
     previous_truncated_rum_by_url.pageviews DESC
 ) WHERE
-  rank <= @limit OR url = "Other" OR @rising;
+  rank <= @limit OR url = "Other" OR @rising
 
-END IF;
 --- avgcls: 75th percentile value of the Cumulative Layout Shift metric in the current period
 --- avgcls_1: 75th percentile value of the CLS metric in the previous period
 --- avgfid: 75th percentile value of the First Input Delay metric in milliseconds in the current period

--- a/src/queries/rum-dashboard.sql
+++ b/src/queries/rum-dashboard.sql
@@ -576,7 +576,7 @@ FROM (
 ) WHERE
   rank <= @limit OR url = "Other" OR @rising;
 
-END IF;
+END IF
 --- avgcls: 75th percentile value of the Cumulative Layout Shift metric in the current period
 --- avgcls_1: 75th percentile value of the CLS metric in the previous period
 --- avgfid: 75th percentile value of the First Input Delay metric in milliseconds in the current period

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -143,7 +143,7 @@ export async function execute(email, key, project, query, _, params = {}, logger
     // eslint-disable-next-line no-param-reassign
     requestParams.limit = parseInt(requestParams.limit, 10);
     const headers = cleanHeaderParams(loadedQuery, headerParams, true);
-    var q = `
+    let q = `
       IF EXISTS(
         SELECT
           *

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -152,7 +152,7 @@ export async function execute(email, key, project, query, _, params = {}, logger
         WHERE
           key_bytes = SHA512(@domainkey)
           AND (revoke_date IS NULL
-            OR revoke_date > CURRENT_DATE(@timezone))
+            OR revoke_date > CURRENT_DATE())
           AND (
             hostname_prefix = ""
             OR @url LIKE CONCAT("%.", hostname_prefix)

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -172,8 +172,9 @@ export async function execute(email, key, project, query, _, params = {}, logger
     `;
 
     // multi-results is a special test query which does not need a domain key check
-    // rorate-domainkeys is a sepcial query which already has a domain key check
-    if (query === '/multi-results' || query === '/rotate-domainkeys') {
+    // rorate-domainkeys is a special query which already has a domain key check
+    // rum-dashboard already has a domain key check
+    if (query === '/multi-results' || query === '/rotate-domainkeys' || query === '/rum-dashboard') {
       q = loadedQuery;
     }
 

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -173,8 +173,7 @@ export async function execute(email, key, project, query, _, params = {}, logger
 
     // multi-results is a special test query which does not need a domain key check
     // rorate-domainkeys is a special query which already has a domain key check
-    // rum-dashboard already has a domain key check
-    if (query === '/multi-results' || query === '/rotate-domainkeys' || query === '/rum-dashboard') {
+    if (query === '/multi-results' || query === '/rotate-domainkeys') {
       q = loadedQuery;
     }
 

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -143,7 +143,7 @@ export async function execute(email, key, project, query, _, params = {}, logger
     // eslint-disable-next-line no-param-reassign
     requestParams.limit = parseInt(requestParams.limit, 10);
     const headers = cleanHeaderParams(loadedQuery, headerParams, true);
-    const q = `
+    var q = `
       IF EXISTS(
         SELECT
           *
@@ -170,6 +170,11 @@ export async function execute(email, key, project, query, _, params = {}, logger
         ;
       END IF;
     `;
+
+    // multi-results is a special test query which does not need a domain key check
+    if (query === '/multi-results') {
+      q = loadedQuery;
+    }
 
     const responseMetadata = {};
 

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -172,7 +172,8 @@ export async function execute(email, key, project, query, _, params = {}, logger
     `;
 
     // multi-results is a special test query which does not need a domain key check
-    if (query === '/multi-results') {
+    // rorate-domainkeys is a sepcial query which already has a domain key check
+    if (query === '/multi-results' || query === '/rotate-domainkeys') {
       q = loadedQuery;
     }
 

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -143,7 +143,33 @@ export async function execute(email, key, project, query, _, params = {}, logger
     // eslint-disable-next-line no-param-reassign
     requestParams.limit = parseInt(requestParams.limit, 10);
     const headers = cleanHeaderParams(loadedQuery, headerParams, true);
-    const q = loadedQuery;
+    const q = `
+      IF EXISTS(
+        SELECT
+          *
+        FROM
+          helix-225321.helix_reporting.domain_keys
+        WHERE
+          key_bytes = SHA512(@domainkey)
+          AND (revoke_date IS NULL
+            OR revoke_date > CURRENT_DATE(@timezone))
+          AND (
+            hostname_prefix = ""
+            OR @url LIKE CONCAT("%.", hostname_prefix)
+            OR @url LIKE CONCAT("%.", hostname_prefix, "/%")
+            OR @url LIKE CONCAT(hostname_prefix)
+            OR @url LIKE CONCAT(hostname_prefix, "/%")
+            -- handle comma-separated list of urls, remove spaces and trailing comma
+            OR hostname_prefix IN (SELECT * FROM helix_rum.URLS_FROM_LIST(@url))
+          )
+        )
+
+      THEN
+
+        ${loadedQuery}
+
+      END IF;
+    `;
 
     const responseMetadata = {};
 

--- a/src/sendquery.js
+++ b/src/sendquery.js
@@ -167,7 +167,7 @@ export async function execute(email, key, project, query, _, params = {}, logger
       THEN
 
         ${loadedQuery}
-
+        ;
       END IF;
     `;
 


### PR DESCRIPTION
Pre-validate domain key for queries per guidance from Lars.  While making this PR, I removed the special handling within /rum-dashboard so that it goes through the same treatment as other queries.

I tested against several queries with `ci7978` which contains this change.  With a valid domain key, it returns the same as `v3`, and a bit slow.  With an invalid domain key, it returns valid JSON with no results very quickly.
