### PR TITLE
update exclusion list for content request API calls

### DIFF
--- a/src/queries/rum-content-requests.sql
+++ b/src/queries/rum-content-requests.sql
@@ -93,6 +93,8 @@ group_all_events_daily AS (
       (
         COUNTIF(
           events.source LIKE '%/api/qraphql/%'
+          OR events.source LIKE '%/libs/%'
+          OR events.source LIKE '%/manifest.json%'
         )
         > 0
       ), false

--- a/src/queries/rum-content-requests.sql
+++ b/src/queries/rum-content-requests.sql
@@ -67,7 +67,7 @@ group_all_events_daily AS (
     COALESCE(
       COUNTIF(
         events.checkpoint = 'loadresource'
-        AND events.target NOT LIKE '%.html'
+        AND events.source NOT LIKE '%.html'
       ),
       0
     )

--- a/test/testContentRequests.js
+++ b/test/testContentRequests.js
@@ -151,15 +151,15 @@ describe('Test Content Requests', () => {
     assert.ok(json.results.data.length === 2, 'expecting 2 entries, 1 for each host for year 2024');
     const expected = [
       {
-        content_requests: 187140,
-        cr_apicalls: 98060,
+        content_requests: 133520,
+        cr_apicalls: 44440,
         cr_margin_of_error: 8556,
         cr_pageviews: 89080,
         error404_requests: 1700,
         hostname: 'blog.adobe.com',
         html_requests: 94880,
         id: '3d8835af40a49938c772d724480e09a35aa9b881',
-        json_requests: 508200,
+        json_requests: 230700,
         month: null,
         time: '2024-01-01T00:00:00+00:00',
         top_host: 'rum.hlx.page',

--- a/test/testContentRequests.js
+++ b/test/testContentRequests.js
@@ -151,8 +151,8 @@ describe('Test Content Requests', () => {
     assert.ok(json.results.data.length === 2, 'expecting 2 entries, 1 for each host for year 2024');
     const expected = [
       {
-        content_requests: 188220,
-        cr_apicalls: 99140,
+        content_requests: 187140,
+        cr_apicalls: 98060,
         cr_margin_of_error: 8556,
         cr_pageviews: 89080,
         error404_requests: 1700,


### PR DESCRIPTION
Updated exclusion list to better match CDN counting logic, most specifically to not count /libs/ JSON files as API calls.
