### PR TITLE
fix [common-event-v5.sql]: remove invalid hostnames #1259

### DIFF
--- a/src/queries/common-event-v5.sql
+++ b/src/queries/common-event-v5.sql
@@ -121,5 +121,7 @@ FUNCTION `helix-225321.helix_rum.EVENTS_V5`( -- noqa: PRS
     (days_count >= 0, DATETIME_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY, helix_rum.CLEAN_TIMEZONE(timezone)), INTERVAL (days_offset + days_count) DAY), TIMESTAMP(day_min, helix_rum.CLEAN_TIMEZONE(timezone))) <= time
     AND helix_rum.CLUSTER_FILTERCLASS(user_agent,
       deviceclass)
+    -- ignore invalid hostnames
+    AND REGEXP_CONTAINS(hostname, r'^[a-zA-Z0-9_\-./]*$') IS TRUE
     AND time < CURRENT_TIMESTAMP()
 );


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
[CR] invalid hostnames break the API #1259
The DaaS team built the Run Helix Query API to load monthly Content Requests (CR) across all hostnames. When the API encounters hostnames containing non-printing or illegal Unicode characters, it returns an empty dataset.

The problem originates from the BigQuery function helix_rum.EVENTS_V5 when using the url parameter set to “-”. This function retrieves data for all hostnames, but many records include invalid hostname values (e.g., hostname?@a.png\u0027"\u003cbmt\u003e for host publish-p23952-e1363387.adobeaemcloud.net).

Thanks for reviewing!
